### PR TITLE
Add informative messages for logged-in methods and fix a bug with sparse accounts

### DIFF
--- a/robin_stocks/account.py
+++ b/robin_stocks/account.py
@@ -4,6 +4,7 @@ import robin_stocks.urls as urls
 import robin_stocks.stocks as stocks
 import robin_stocks.profiles as profiles
 
+@helper.login_required
 def get_all_positions(info=None):
     """Returns a list containing every position ever traded.
 
@@ -18,6 +19,7 @@ def get_all_positions(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_current_positions(info=None):
     """Returns a list of stocks/options that are currently held.
 
@@ -33,6 +35,7 @@ def get_current_positions(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_dividends(info=None):
     """Returns a list of dividend trasactions that include information such as the percentage rate,
     amount, shares of held stock, and date paid.
@@ -48,6 +51,7 @@ def get_dividends(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_total_dividends():
     """Returns a float number representing the total amount of dividends paid to the account.
 
@@ -62,6 +66,7 @@ def get_total_dividends():
         dividend_total += float(item['amount'])
     return(dividend_total)
 
+@helper.login_required
 def get_notifications(info=None):
     """Returns a list of notifications.
 
@@ -76,6 +81,7 @@ def get_notifications(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_latest_notification():
     """Returns the time of the latest notification.
 
@@ -86,6 +92,7 @@ def get_latest_notification():
     data = helper.request_get(url)
     return(data)
 
+@helper.login_required
 def get_wire_transfers(info=None):
     """Returns a list of wire transfers.
 
@@ -99,6 +106,7 @@ def get_wire_transfers(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_margin_calls(symbol=None):
     """Returns either all margin calls or margin calls for a specific stock.
 
@@ -121,6 +129,7 @@ def get_margin_calls(symbol=None):
 
     return(data)
 
+@helper.login_required
 def get_linked_bank_accounts(info=None):
     """Returns all linked bank accounts.
 
@@ -133,6 +142,7 @@ def get_linked_bank_accounts(info=None):
     data = helper.request_get(url,'results')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_bank_account_info(id,info=None):
     """Returns a single dictionary of bank information
 
@@ -148,6 +158,7 @@ def get_bank_account_info(id,info=None):
     data = helper.request_get(url)
     return(helper.filter(data,info))
 
+@helper.login_required
 def unlink_bank_account(id):
     """Unlinks a bank account.
 
@@ -160,6 +171,7 @@ def unlink_bank_account(id):
     data = helper.request_post(url)
     return(data)
 
+@helper.login_required
 def get_bank_transfers(info=None):
     """Returns all bank transfers made for the account.
 
@@ -173,6 +185,7 @@ def get_bank_transfers(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_stock_loan_payments(info=None):
     """Returns a list of loan payments.
 
@@ -186,6 +199,7 @@ def get_stock_loan_payments(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_margin_interest(info=None):
     """Returns a list of margin interest.
 
@@ -199,6 +213,7 @@ def get_margin_interest(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_subscription_fees(info=None):
     """Returns a list of subscription fees.
 
@@ -212,6 +227,7 @@ def get_subscription_fees(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_referrals(info=None):
     """Returns a list of referrals.
 
@@ -225,6 +241,7 @@ def get_referrals(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_day_trades(info=None):
     """Returns recent day trades.
 
@@ -239,6 +256,7 @@ def get_day_trades(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_documents(info=None):
     """Returns a list of documents that have been released by Robinhood to the account.
 
@@ -253,6 +271,7 @@ def get_documents(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def download_document(url,name=None,dirpath=None):
     """Downloads a document and saves as it as a PDF. If no name is given, document is saved as
     the name that Robinhood has for the document. If no directory is given, document is saved in the root directory of code.
@@ -285,6 +304,7 @@ def download_document(url,name=None,dirpath=None):
 
     return(data)
 
+@helper.login_required
 def download_all_documents(doctype=None,dirpath=None):
     """Downloads all the documents associated with an account and saves them as a PDF.
     If no name is given, document is saved as a combination of the data of creation, type, and id.
@@ -339,6 +359,7 @@ def download_all_documents(doctype=None,dirpath=None):
 
     return(documents)
 
+@helper.login_required
 def get_all_watchlists(info=None):
     """Returns a list of all watchlists that have been created. Everone has a 'default' watchlist.
 
@@ -351,6 +372,7 @@ def get_all_watchlists(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_watchlist_by_name(name='Default',info=None):
     """Returns a list of information related to the stocks in a single watchlist.
 
@@ -365,6 +387,7 @@ def get_watchlist_by_name(name='Default',info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def post_symbols_to_watchlist(inputSymbols,name='Default'):
     """Posts multiple stock tickers to a watchlist.
 
@@ -384,6 +407,7 @@ def post_symbols_to_watchlist(inputSymbols,name='Default'):
 
     return(data)
 
+@helper.login_required
 def delete_symbols_from_watchlist(inputSymbols,name='Default'):
     """Deletes multiple stock tickers from a watchlist.
 
@@ -413,6 +437,7 @@ def delete_symbols_from_watchlist(inputSymbols,name='Default'):
 
     return(data)
 
+@helper.login_required
 def build_holdings():
     """Builds a dictionary of important information regarding the stocks and positions owned by the user.
 
@@ -462,6 +487,7 @@ def build_holdings():
 
     return(holdings)
 
+@helper.login_required
 def build_user_profile():
     """Builds a dictionary of important information regarding the user account.
 

--- a/robin_stocks/account.py
+++ b/robin_stocks/account.py
@@ -446,10 +446,12 @@ def build_holdings():
     percentage of portfolio, and average buy price.
 
     """
-    holdings = {}
     positions_data = get_current_positions()
     portfolios_data = profiles.load_portfolio_profile()
     accounts_data = profiles.load_account_profile()
+
+    if not positions_data or not portfolios_data or not accounts_data:
+        return({})
 
     if portfolios_data['extended_hours_equity'] is not None:
         total_equity = max(float(portfolios_data['equity']),float(portfolios_data['extended_hours_equity']))
@@ -458,7 +460,12 @@ def build_holdings():
 
     cash = "{0:.2f}".format(float(accounts_data['cash'])+float(accounts_data['uncleared_deposits']))
 
+    holdings = {}
     for item in positions_data:
+        # It is possible for positions_data to be [None]
+        if not item:
+            continue
+
         instrument_data = stocks.get_instrument_by_url(item['instrument'])
         symbol = instrument_data['symbol']
         fundamental_data = stocks.get_fundamentals(symbol)[0]
@@ -499,11 +506,13 @@ def build_user_profile():
     portfolios_data = profiles.load_portfolio_profile()
     accounts_data = profiles.load_account_profile()
 
-    user['equity'] = portfolios_data['equity']
-    user['extended_hours_equity'] = portfolios_data['extended_hours_equity']
+    if portfolios_data:
+      user['equity'] = portfolios_data['equity']
+      user['extended_hours_equity'] = portfolios_data['extended_hours_equity']
 
-    cash = "{0:.2f}".format(float(accounts_data['cash'])+float(accounts_data['uncleared_deposits']))
-    user['cash'] = cash
+    if accounts_data:
+      cash = "{0:.2f}".format(float(accounts_data['cash'])+float(accounts_data['uncleared_deposits']))
+      user['cash'] = cash
 
     user['dividend_total'] = get_total_dividends()
 

--- a/robin_stocks/authentication.py
+++ b/robin_stocks/authentication.py
@@ -32,8 +32,7 @@ def login(username,password,expiresIn=86400,scope='internal'):
     data = helper.request_post(url,payload) 
     token = 'Bearer {}'.format(data['access_token'])
     helper.update_session('Authorization',token)
-    global __is_logged_in__
-    __is_logged_in__ = True
+    helper.set_login_state(True)
     return(data)
 
 @helper.login_required
@@ -43,6 +42,5 @@ def logout():
     :returns: None
 
     """
-    global __is_logged_in__
-    __is_logged_in__ = False
+    helper.set_login_state(False)
     helper.update_session('Authorization',None)

--- a/robin_stocks/authentication.py
+++ b/robin_stocks/authentication.py
@@ -16,6 +16,10 @@ def login(username,password,expiresIn=86400,scope='internal'):
     :returns:  A dictionary with log in information.
 
     """
+    if not username or not password: 
+        raise Exception('login must be called with a non-empty username and '
+            'password')
+
     url = urls.login_url()
     payload = {
     'client_id': 'c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS',
@@ -28,12 +32,17 @@ def login(username,password,expiresIn=86400,scope='internal'):
     data = helper.request_post(url,payload) 
     token = 'Bearer {}'.format(data['access_token'])
     helper.update_session('Authorization',token)
+    global __is_logged_in__
+    __is_logged_in__ = True
     return(data)
 
+@helper.login_required
 def logout():
     """Removes authorization from the session header.
 
     :returns: None
 
     """
+    global __is_logged_in__
+    __is_logged_in__ = False
     helper.update_session('Authorization',None)

--- a/robin_stocks/helper.py
+++ b/robin_stocks/helper.py
@@ -3,15 +3,19 @@ import requests
 
 __is_logged_in__ = False
 
+def set_login_state(logged_in):
+    global __is_logged_in__
+    __is_logged_in__ = logged_in
+
 def login_required(func):
     """A decorator for indicating which methods require the user to be logged
        in."""
-    def login_wrapper():
+    def login_wrapper(*args, **kwargs):
       global __is_logged_in__
       if not __is_logged_in__:
           raise Exception('{} can only be called when logged in'.format(
               func.__name__))
-      func(*args, **kwargs)
+      return func(*args, **kwargs)
     return login_wrapper
 
 def id_for_stock(symbol):
@@ -114,7 +118,7 @@ def filter(data,info):
 
     """
     if (data == None or data == [None]):
-        return None
+        return data
     elif (type(data) == list):
         if (len(data) == 0):
             return([None])

--- a/robin_stocks/helper.py
+++ b/robin_stocks/helper.py
@@ -4,6 +4,8 @@ import requests
 __is_logged_in__ = False
 
 def login_required(func):
+    """A decorator for indicating which methods require the user to be logged
+       in."""
     def login_wrapper():
       global __is_logged_in__
       if not __is_logged_in__:

--- a/robin_stocks/helper.py
+++ b/robin_stocks/helper.py
@@ -1,6 +1,17 @@
 from robin_stocks.constants import Session
 import requests
 
+__is_logged_in__ = False
+
+def login_required(func):
+    def login_wrapper():
+      global __is_logged_in__
+      if not __is_logged_in__:
+          raise Exception('{} can only be called when logged in'.format(
+              func.__name__))
+      func(*args, **kwargs)
+    return login_wrapper
+
 def id_for_stock(symbol):
     """Takes a stock ticker and returns the instrument id associated with the stock.
 
@@ -101,7 +112,7 @@ def filter(data,info):
 
     """
     if (data == None or data == [None]):
-        return data
+        return None
     elif (type(data) == list):
         if (len(data) == 0):
             return([None])

--- a/robin_stocks/options.py
+++ b/robin_stocks/options.py
@@ -1,6 +1,7 @@
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
 
+@helper.login_required
 def get_aggregate_positions(info=None):
     """Collapses all option orders for a stock into a single dictionary.
 
@@ -14,6 +15,7 @@ def get_aggregate_positions(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_market_options(info=None):
     """Returns a list of all options.
 
@@ -28,6 +30,7 @@ def get_market_options(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_all_option_positions(info=None):
     """Returns all option positions ever held for the account.
 
@@ -41,6 +44,7 @@ def get_all_option_positions(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_open_option_positions(info=None):
     """Returns all open option positions for the account.
 

--- a/robin_stocks/orders.py
+++ b/robin_stocks/orders.py
@@ -3,6 +3,7 @@ import robin_stocks.urls as urls
 import robin_stocks.stocks as stocks
 import robin_stocks.profiles as profiles
 
+@helper.login_required
 def get_all_orders(info=None):
     """Returns a list of all the orders that have been processed for the account.
 
@@ -16,6 +17,7 @@ def get_all_orders(info=None):
     data = helper.request_get(url,'pagination')
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_all_open_orders(info=None):
     """Returns a list of all the orders that are currently open.
 
@@ -32,6 +34,7 @@ def get_all_open_orders(info=None):
 
     return(helper.filter(data,info))
 
+@helper.login_required
 def get_order_info(orderID):
     """Returns the information for a single order.
 
@@ -44,6 +47,7 @@ def get_order_info(orderID):
     data = helper.request_get(url)
     return(data)
 
+@helper.login_required
 def find_orders(**arguments):
     """Returns a list of orders that match the keyword parameters.
 
@@ -82,6 +86,7 @@ def find_orders(**arguments):
 
     return(list_of_orders)
 
+@helper.login_required
 def cancel_all_open_orders():
     """Cancels all open orders.
 
@@ -100,6 +105,7 @@ def cancel_all_open_orders():
     print('All Orders Cancelled')
     return(items)
 
+@helper.login_required
 def cancel_order(orderID):
     """Cancels a specific order.
 
@@ -115,6 +121,7 @@ def cancel_order(orderID):
         print('Order '+order_id+' cancelled')
     return(data)
 
+@helper.login_required
 def order_buy_market(symbol,quantity,timeInForce='gtc',extendedHours='false'):
     """Submits a market order to be executed immediately.
 
@@ -157,6 +164,7 @@ def order_buy_market(symbol,quantity,timeInForce='gtc',extendedHours='false'):
 
     return(data)
 
+@helper.login_required
 def order_buy_limit(symbol,quantity,limitPrice,timeInForce='gtc'):
     """Submits a limit order to be executed once a certain price is reached.
 
@@ -199,6 +207,7 @@ def order_buy_limit(symbol,quantity,limitPrice,timeInForce='gtc'):
 
     return(data)
 
+@helper.login_required
 def order_buy_stop_loss(symbol,quantity,stopPrice,timeInForce='gtc'):
     """Submits a stop order to be turned into a market order once a certain stop price is reached.
 
@@ -246,6 +255,7 @@ def order_buy_stop_loss(symbol,quantity,stopPrice,timeInForce='gtc'):
 
     return(data)
 
+@helper.login_required
 def order_buy_stop_limit(symbol,quantity,limitPrice,stopPrice,timeInForce='gtc'):
     """Submits a stop order to be turned into a limit order once a certain stop price is reached.
 
@@ -296,6 +306,7 @@ def order_buy_stop_limit(symbol,quantity,limitPrice,stopPrice,timeInForce='gtc')
 
     return(data)
 
+@helper.login_required
 def order_sell_market(symbol,quantity,timeInForce='gtc', extendedHours='false'):
     """Submits a market order to be executed immediately.
 
@@ -338,6 +349,7 @@ def order_sell_market(symbol,quantity,timeInForce='gtc', extendedHours='false'):
 
     return(data)
 
+@helper.login_required
 def order_sell_limit(symbol,quantity,limitPrice,timeInForce='gtc'):
     """Submits a limit order to be executed once a certain price is reached.
 
@@ -380,6 +392,7 @@ def order_sell_limit(symbol,quantity,limitPrice,timeInForce='gtc'):
 
     return(data)
 
+@helper.login_required
 def order_sell_stop_loss(symbol,quantity,stopPrice,timeInForce='gtc'):
     """Submits a stop order to be turned into a market order once a certain stop price is reached.
 
@@ -427,6 +440,7 @@ def order_sell_stop_loss(symbol,quantity,stopPrice,timeInForce='gtc'):
 
     return(data)
 
+@helper.login_required
 def order_sell_stop_limit(symbol,quantity,limitPrice,stopPrice,timeInForce='gtc'):
     """Submits a stop order to be turned into a limit order once a certain stop price is reached.
 
@@ -477,6 +491,7 @@ def order_sell_stop_limit(symbol,quantity,limitPrice,stopPrice,timeInForce='gtc'
 
     return(data)
 
+@helper.login_required
 def order(symbol,quantity,orderType,limitPrice,stopPrice,trigger,side,timeInForce,extendedHours):
     """A generic order function. All parameters must be supplied.
 

--- a/robin_stocks/profiles.py
+++ b/robin_stocks/profiles.py
@@ -1,6 +1,7 @@
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
 
+@helper.login_required
 def load_account_profile(info=None):
     """Gets the information associated with the accounts profile,including day
     trading information and cash being held by Robinhood.
@@ -16,6 +17,7 @@ def load_account_profile(info=None):
     data = helper.request_get(url,'indexzero')
     return(helper.filter(data,info))
 
+@helper.login_required
 def load_basic_profile(info=None):
     """Gets the information associated with the personal profile,
     such as phone number, city, marital status, and date of birth.
@@ -31,6 +33,7 @@ def load_basic_profile(info=None):
     data = helper.request_get(url)
     return(helper.filter(data,info))
 
+@helper.login_required
 def load_investment_profile(info=None):
     """Gets the information associated with the investment profile.
     These are the answers to the questionaire you filled out when you made your profile.
@@ -46,6 +49,7 @@ def load_investment_profile(info=None):
     data = helper.request_get(url)
     return(helper.filter(data,info))
 
+@helper.login_required
 def load_portfolio_profile(info=None):
     """Gets the information associated with the portfolios profile,
     such as withdrawable amount, market value of account, and excess margin.
@@ -61,6 +65,7 @@ def load_portfolio_profile(info=None):
     data = helper.request_get(url,'indexzero')
     return(helper.filter(data,info))
 
+@helper.login_required
 def load_security_profile(info=None):
     """Gets the information associated with the security profile.
 
@@ -75,6 +80,7 @@ def load_security_profile(info=None):
     data = helper.request_get(url)
     return(helper.filter(data,info))
 
+@helper.login_required
 def load_user_profile(info=None):
     """Gets the information associated with the user profile,
     such as username, email, and links to the urls for other profiles.


### PR DESCRIPTION
The first fix is adding a decorator to let users know when they are calling a method that requires them to be logged in and prints a readable error message if it is violated.

The second fix addresses an issue I found with my sparse test account which will crash if build_holdings() is called without any holdings.  Rather than returning empty (correct) it previously threw an exception.