### PR TITLE
print generated device token

### DIFF
--- a/robin_stocks/authentication.py
+++ b/robin_stocks/authentication.py
@@ -27,7 +27,7 @@ def generate_device_token():
 
         if (i == 3) or (i == 5) or (i == 7) or (i == 9):
             id += "-"
-
+    print(f'generated device_token: {id}')
     return(id)
 
 def base_login(username,password,device_token,expiresIn=86400,scope='internal'):
@@ -66,7 +66,7 @@ def base_login(username,password,device_token,expiresIn=86400,scope='internal'):
     return(data)
 
 def respond_to_challenge(challenge_id, sms_code):
-    """This functino will post to the challenge url.
+    """This function will post to the challenge url.
 
     :param challenge_id: The challenge id.
     :type challenge_id: str


### PR DESCRIPTION
Useful for subsequent logins. If you reuse the same device id, 2FA isn't required for every login. 

Logging in with a pre-created id (not one generated by the script)
> `r.login(EMAIL, PW, DEVICE_ID)`

won't prompt the script to ask for the sms/email code and fail.