### PR TITLE
Update orders.py

### DIFF
--- a/robin_stocks/orders.py
+++ b/robin_stocks/orders.py
@@ -666,7 +666,7 @@ def order_sell_option_limit(price, symbol, quantity, expirationDate, strike, opt
     'direction': 'credit',
     'time_in_force': timeInForce,
     'legs': [
-        {'position_effect': 'open', 'side' : 'sell', 'ratio_quantity': 1, 'option': urls.option_instruments(optionID) },
+        {'position_effect': 'close', 'side' : 'sell', 'ratio_quantity': 1, 'option': urls.option_instruments(optionID) },
     ],
     'type': 'limit',
     'trigger': 'immediate',


### PR DESCRIPTION
To sell the option which is already open , position_effect must be "close"

FYI. I've tested the orders going through.
Will add more code to "sell_to_open", "buy_to_close" methods to it. with separate pull request - enhancement.