### PR TITLE
Adding symbol property to Stock result

### DIFF
--- a/robin_stocks/stocks.py
+++ b/robin_stocks/stocks.py
@@ -52,6 +52,8 @@ def get_fundamentals(inputSymbols, info = None):
     for count, item in enumerate(data):
         if item is None:
             print(helper.error_ticker_does_not_exist(symbols[count]))
+        else:
+            item['symbol'] = symbols[count]
 
     data = [item for item in data if item is not None]
 


### PR DESCRIPTION
When multiple symbols are requested and if some of them don't exist on Robinhood, the result just simply omit the symbols. It's not possible to know what exact symbols are missed, because request / result are just lists, no way to match them. By adding _symbol_ property to stock result, it can easily figure out what symbols are valid ones.