### PR TITLE
Fixed selling fractional only at 6 decimals and <= 1.00 to <1.00

### DIFF
--- a/robin_stocks/orders.py
+++ b/robin_stocks/orders.py
@@ -361,7 +361,7 @@ def order_buy_fractional_by_quantity(symbol, quantity, timeInForce='gfd', extend
         'instrument': stocks.get_instruments_by_symbols(symbol, info='url')[0],
         'symbol': symbol,
         'price': helper.round_price(stock_price),
-        'quantity': quantity,
+        'quantity': helper.round_price(quantity),
         'ref_id': str(uuid4()),
         'type': 'market',
         'stop_price': None,
@@ -405,8 +405,8 @@ def order_buy_fractional_by_price(symbol, amountInDollars, timeInForce='gfd', ex
         print(message)
         return None
 
-    if amountInDollars <= 1:
-        print("Fractional share price should meet minimum 1.00.")
+    if amountInDollars < 1:
+        print("ERROR: Fractional share price should meet minimum 1.00.")
         return None
 
     stock_price = stocks.get_latest_price(symbol)[0]
@@ -659,7 +659,7 @@ def order_sell_fractional_by_quantity(symbol, quantity, timeInForce='gfd', exten
         'instrument': stocks.get_instruments_by_symbols(symbol, info='url')[0],
         'symbol': symbol,
         'price': helper.round_price(stock_price),
-        'quantity': quantity,
+        'quantity': helper.round_price(quantity),
         'ref_id': str(uuid4()),
         'type': 'market',
         'stop_price': None,
@@ -703,8 +703,8 @@ def order_sell_fractional_by_price(symbol, amountInDollars, timeInForce='gfd', e
         print(message)
         return None
 
-    if amountInDollars <= 1:
-        print("Fractional share price should meet minimum 1.00.")
+    if amountInDollars < 1:
+        print("ERROR: Fractional share price should meet minimum 1.00.")
         return None
 
     stock_price = stocks.get_latest_price(symbol)[0]


### PR DESCRIPTION
Also when you buy fractions which equate to less than <$1.00 in RH may fail occasionally. Needs an helper which computes least possible fractional quantity before sending the order.
@jmfernandes How do you get average stock price from the stock_info? Would be useful to compute fractions on avg price for volatile stocks and that appears to be RH implementation as well.