### PR TITLE
Added new url syntax for getting watchlists

### DIFF
--- a/robin_stocks/account.py
+++ b/robin_stocks/account.py
@@ -474,7 +474,7 @@ def get_all_watchlists(info=None):
 
     """
     url = urls.watchlists()
-    data = helper.request_get(url, 'pagination')
+    data = helper.request_get(url, 'result')
     return(helper.filter(data, info))
 
 
@@ -489,8 +489,16 @@ def get_watchlist_by_name(name='Default', info=None):
     :returns: Returns a list of dictionaries that contain the instrument urls and a url that references itself.
 
     """
+
+    #Get id of requested watchlist
+    all_watchlists = get_all_watchlists()
+    watchlist_id = ''
+    for wl in all_watchlists['results']:
+        if wl['display_name'] == name:
+            watchlist_id = wl['id']
+
     url = urls.watchlists(name)
-    data = helper.request_get(url, 'pagination')
+    data = helper.request_get(url,'list_id',{'list_id':watchlist_id})
     return(helper.filter(data, info))
 
 

--- a/robin_stocks/urls.py
+++ b/robin_stocks/urls.py
@@ -147,9 +147,9 @@ def watchlists(name=None, add=False):
         return('https://api.robinhood.com/watchlists/{0}/bulk_add/'.format(name))
 
     if name:
-        return('https://api.robinhood.com/watchlists/{0}/'.format(name))
+        return('https://api.robinhood.com/midlands/lists/items/')
     else:
-        return('https://api.robinhood.com/watchlists/')
+        return('https://api.robinhood.com/midlands/lists/default/')
 
 # markets
 


### PR DESCRIPTION
As mentioned in the following issue: https://github.com/jmfernandes/robin_stocks/issues/134

It was not possible to query custom watchlist information. This pull request fixes the problem with an updated url syntax and query to get custom list data.