### PR TITLE
Fix dividend calculation

### DIFF
--- a/examples/get_accurate_gains.py
+++ b/examples/get_accurate_gains.py
@@ -18,21 +18,23 @@ password = ''
 login = r.login(username,password)
 
 profileData = r.load_portfolio_profile()
-#print(profileData)
 allTransactions = r.get_bank_transfers()
 cardTransactions= r.get_card_transactions()
 
 deposits = sum(float(x['amount']) for x in allTransactions if (x['direction'] == 'deposit') and (x['state'] == 'completed'))
 withdrawals = sum(float(x['amount']) for x in allTransactions if (x['direction'] == 'withdraw') and (x['state'] == 'completed'))
 debits = sum(float(x['amount']['amount']) for x in cardTransactions if (x['direction'] == 'debit' and (x['transaction_type'] == 'settled')))
-money_invested = deposits - (withdrawals - debits)
+reversal_fees = sum(float(x['fees']) for x in allTransactions if (x['direction'] == 'deposit') and (x['state'] == 'reversed'))
 
+money_invested = deposits + reversal_fees - (withdrawals - debits)
 dividends = r.get_total_dividends()
 percentDividend = dividends/money_invested*100
 
-totalGainMinusDividends =float(profileData['extended_hours_equity'])-dividends-money_invested
+equity = float(profileData['extended_hours_equity'])
+totalGainMinusDividends = equity - dividends - money_invested
 percentGain = totalGainMinusDividends/money_invested*100
 
-print("The total money invested is {}".format(money_invested))
-print("The net worth has increased {:0.2}% due to dividends".format(percentDividend))
-print("The net worth has increased {:0.3}% due to other gains".format(percentGain))
+print("The total money invested is {:.2f}".format(money_invested))
+print("The total equity is {:.2f}".format(equity))
+print("The net worth has increased {:0.2}% due to dividends that amount to {:0.2f}".format(percentDividend, dividends))
+print("The net worth has increased {:0.3}% due to other gains that amount to {:0.2f}".format(percentGain, totalGainMinusDividends))

--- a/robin_stocks/account.py
+++ b/robin_stocks/account.py
@@ -151,7 +151,7 @@ def get_total_dividends():
 
     dividend_total = 0
     for item in data:
-        dividend_total += float(item['amount'])
+        dividend_total += float(item['amount']) if (item['state'] == 'paid' or item['state'] == 'reinvested') else 0
     return(dividend_total)
 
 

--- a/robin_stocks/authentication.py
+++ b/robin_stocks/authentication.py
@@ -35,7 +35,7 @@ def generate_device_token():
 
 
 def respond_to_challenge(challenge_id, sms_code):
-    """This functino will post to the challenge url.
+    """This function will post to the challenge url.
 
     :param challenge_id: The challenge id.
     :type challenge_id: str
@@ -52,7 +52,7 @@ def respond_to_challenge(challenge_id, sms_code):
 
 
 def login(username=None, password=None, expiresIn=86400, scope='internal', by_sms=True, store_session=True, mfa_code=None):
-    """This function will effectivly log the user into robinhood by getting an
+    """This function will effectively log the user into robinhood by getting an
     authentication token and saving it to the session header. By default, it
     will store the authentication token in a pickle file and load that value
     on subsequent logins.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='1.4.0',
+      version='1.4.1',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
In the get_total_dividends() method, when we check each item in data, we simply use item['account'] in the sum. However, that can result in over-counting in the case where you have transactions with 'voided' state. There could be other such states, and hence the safest way is to only include states that are known to be yielding the right dividend transactions, i.e 'paid' and 'reinvested'.