### PR TITLE
Update get_top_movers functionality

### DIFF
--- a/robin_stocks/__init__.py
+++ b/robin_stocks/__init__.py
@@ -50,8 +50,9 @@ from .helper import request_get,      \
 
 from .markets import get_currency_pairs,        \
                      get_markets,               \
-                     get_top_movers
-
+                     get_top_movers,             \
+                     get_top_movers_sp500
+                     
 from .options import get_aggregate_positions,                           \
                      get_market_options,                                \
                      get_all_option_positions,                          \

--- a/robin_stocks/markets.py
+++ b/robin_stocks/markets.py
@@ -48,7 +48,7 @@ def get_top_movers(info=None):
     return(helper.filter(data, info))
 
 
-def get_markets(info='instruments'):
+def get_markets(info=None):
     """Returns a list of available markets.
 
     :param info: Will filter the results to get a specific value.

--- a/robin_stocks/markets.py
+++ b/robin_stocks/markets.py
@@ -1,10 +1,10 @@
 """Contains functions for getting market level data."""
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
+import robin_stocks.stocks as stocks
 
-
-def get_top_movers(direction, info=None):
-    """Returns a list of the top movers up or down for the day.
+def get_top_movers_sp500(direction, info=None):
+    """Returns a list of the top S&P500 movers up or down for the day.
 
     :param direction: The direction of movement either 'up' or 'down'
     :type direction: str
@@ -24,14 +24,31 @@ def get_top_movers(direction, info=None):
         print('Error: direction must be "up" or "down"')
         return([None])
 
-    url = urls.movers()
+    url = urls.movers_sp500()
     payload = {'direction': direction}
     data = helper.request_get(url, 'pagination', payload)
 
     return(helper.filter(data, info))
 
+def get_top_movers(info=None):
+    """Returns a list of the Top 20 movers on Robin Hood.
 
-def get_markets(info=None):
+    :type info: Optional[str]
+    :returns: Returns a list of dictionaries of key/value pairs for each mover. If info parameter is provided, \
+    a list of strings is returned where the strings are the value of the key that matches info.
+
+    """
+    url = urls.movers_top()
+    data = helper.request_get(url, 'regular')
+    data = helper.filter(data, 'instruments')
+    
+    symbols = [stocks.get_symbol_by_url(x) for x in data] 
+    data = stocks.get_quotes(symbols)
+    
+    return(helper.filter(data, info))
+
+
+def get_markets(info='instruments'):
     """Returns a list of available markets.
 
     :param info: Will filter the results to get a specific value.

--- a/robin_stocks/urls.py
+++ b/robin_stocks/urls.py
@@ -168,9 +168,11 @@ def currency():
 def markets():
     return('https://api.robinhood.com/markets/')
 
-
-def movers():
+def movers_sp500():
     return('https://api.robinhood.com/midlands/movers/sp500/')
+
+def movers_top():
+    return('https://api.robinhood.com/midlands/tags/tag/top-movers/')
 
 # options
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='1.4.0',
+      version='1.5.0',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Hey started playing with this yesterday, wanted to pull Robin Hood Top Movers data. Realized `get_top_movers()` was pulling from the S&P endpoint.

I updated `get_top_movers()` so it pulls from the `/midlands/tags/tag/top-movers/` API, which matches the Top Movers data that Robin Hood displays. I moved the old `get_top_movers()` into `get_top_movers_sp500()` so the old functionality is available for anyone who wants it.