### PR TITLE
Allow the print() output to go to anywhere

### DIFF
--- a/robin_stocks/__init__.py
+++ b/robin_stocks/__init__.py
@@ -47,7 +47,9 @@ from .helper import request_get,      \
                     request_post,     \
                     request_delete,   \
                     request_document, \
-                    update_session
+                    update_session,   \
+                    set_output,       \
+                    get_output                       
 
 from .markets import get_currency_pairs,                    \
                      get_markets,                           \

--- a/robin_stocks/account.py
+++ b/robin_stocks/account.py
@@ -55,19 +55,19 @@ def get_historical_portfolio(interval=None, span='week', bounds='regular',info=N
 
     if interval not in interval_check:
         if interval is None and (bounds != 'regular' and span != 'all'):
-            print ('ERROR: Interval must be None for "all" span "regular" bounds')
+            print ('ERROR: Interval must be None for "all" span "regular" bounds', file=helper.get_output())
             return ([None])
         print(
-            'ERROR: Interval must be "5minute","10minute","hour","day",or "week"')
+            'ERROR: Interval must be "5minute","10minute","hour","day",or "week"', file=helper.get_output())
         return([None])
     if span not in span_check:
-        print('ERROR: Span must be "day","week","month","3month","year",or "5year"')
+        print('ERROR: Span must be "day","week","month","3month","year",or "5year"', file=helper.get_output())
         return([None])
     if bounds not in bounds_check:
         print('ERROR: Bounds must be "extended","regular",or "trading"')
         return([None])
     if (bounds == 'extended' or bounds == 'trading') and span != 'day':
-        print('ERROR: extended and trading bounds can only be used with a span of "day"')
+        print('ERROR: extended and trading bounds can only be used with a span of "day"', file=helper.get_output())
         return([None])
 
     account = profiles.load_account_profile('account_number')
@@ -282,7 +282,7 @@ def get_margin_calls(symbol=None):
         try:
             symbol = symbol.upper().strip()
         except AttributeError as message:
-            print(message)
+            print(message, file=helper.get_output())
             return None
         payload = {'equity_instrument_id', helper.id_for_stock(symbol)}
         data = helper.request_get(url, 'results', payload)
@@ -479,7 +479,7 @@ def download_document(url, name=None, dirpath=None):
     """
     data = helper.request_document(url)
 
-    print('Writing PDF...')
+    print('Writing PDF...', file=helper.get_output())
     if not name:
         name = url[36:].split('/', 1)[0]
 
@@ -530,7 +530,7 @@ def download_all_documents(doctype=None, dirpath=None):
                 open(filename, 'wb').write(data.content)
                 downloaded_files = True
                 counter += 1
-                print('Writing PDF {}...'.format(counter))
+                print('Writing PDF {}...'.format(counter), file=helper.get_output())
         else:
             if item['type'] == doctype:
                 data = helper.request_document(item['download_url'])
@@ -542,17 +542,17 @@ def download_all_documents(doctype=None, dirpath=None):
                     open(filename, 'wb').write(data.content)
                     downloaded_files = True
                     counter += 1
-                    print('Writing PDF {}...'.format(counter))
+                    print('Writing PDF {}...'.format(counter), file=helper.get_output())
 
     if downloaded_files == False:
-        print('WARNING: Could not find files of that doctype to download')
+        print('WARNING: Could not find files of that doctype to download', file=helper.get_output())
     else:
         if counter == 1:
             print('Done - wrote {} file to {}'.format(counter,
-                                                      os.path.abspath(directory)))
+                                                      os.path.abspath(directory)), file=helper.get_output())
         else:
             print('Done - wrote {} files to {}'.format(counter,
-                                                       os.path.abspath(directory)))
+                                                       os.path.abspath(directory)), file=helper.get_output())
 
     return(documents)
 

--- a/robin_stocks/authentication.py
+++ b/robin_stocks/authentication.py
@@ -7,7 +7,6 @@ import random
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
 
-
 def generate_device_token():
     """This function will generate a token used when loggin on.
 
@@ -134,7 +133,7 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', by_sm
                             'backup_code': None, 'refresh_token': refresh_token})
             except:
                 print(
-                    "ERROR: There was an issue loading pickle file. Authentication may be expired - logging in normally.")
+                    "ERROR: There was an issue loading pickle file. Authentication may be expired - logging in normally.", file=helper.get_output())
                 helper.set_login_state(False)
                 helper.update_session('Authorization', None)
         else:

--- a/robin_stocks/crypto.py
+++ b/robin_stocks/crypto.py
@@ -2,7 +2,6 @@
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
 
-
 @helper.login_required
 def load_crypto_profile(info=None):
     """Gets the information associated with the crypto account.
@@ -200,16 +199,16 @@ def get_crypto_historicals(symbol, interval='hour', span='week', bounds='24_7', 
 
     if interval not in interval_check:
         print(
-            'ERROR: Interval must be "15second","5minute","10minute","hour","day",or "week"')
+            'ERROR: Interval must be "15second","5minute","10minute","hour","day",or "week"', file=helper.get_output())
         return([None])
     if span not in span_check:
-        print('ERROR: Span must be "hour","day","week","month","3month","year",or "5year"')
+        print('ERROR: Span must be "hour","day","week","month","3month","year",or "5year"', file=helper.get_output())
         return([None])
     if bounds not in bounds_check:
-        print('ERROR: Bounds must be "24_7","extended","regular",or "trading"')
+        print('ERROR: Bounds must be "24_7","extended","regular",or "trading"', file=helper.get_output())
         return([None])
     if (bounds == 'extended' or bounds == 'trading') and span != 'day':
-        print('ERROR: extended and trading bounds can only be used with a span of "day"')
+        print('ERROR: extended and trading bounds can only be used with a span of "day"', file=helper.get_output())
         return([None])
 
 

--- a/robin_stocks/globals.py
+++ b/robin_stocks/globals.py
@@ -1,4 +1,7 @@
 """Holds the session header and other global variables."""
+import sys
+import os
+
 from requests import Session
 
 # Keeps track on if the user is logged in or not.
@@ -14,3 +17,12 @@ SESSION.headers = {
     "Connection": "keep-alive",
     "User-Agent": "*"
 }
+
+#All print() statement direct their output to this stream
+#by default, we use stdout which is the existing behavior
+#but a client can change to any normal Python stream that
+#print() accepts.  Common options are
+#sys.stderr for standard error
+#open(os.devnull,"w") for dev null
+#io.StringIO() to go to a string for the client to inspect
+OUTPUT=sys.stdout

--- a/robin_stocks/markets.py
+++ b/robin_stocks/markets.py
@@ -22,11 +22,11 @@ def get_top_movers_sp500(direction, info=None):
     try:
         direction = direction.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     if (direction != 'up' and direction != 'down'):
-        print('Error: direction must be "up" or "down"')
+        print('Error: direction must be "up" or "down"', file=helper.get_output())
         return([None])
 
     url = urls.movers_sp500()
@@ -132,7 +132,7 @@ def get_all_stocks_from_market_tag(tag, info=None):
     data = helper.filter(data, 'instruments')
 
     if not data:
-        print('ERROR: "{}" is not a valid tag'.format(tag))
+        print('ERROR: "{}" is not a valid tag'.format(tag), file=helper.get_output())
         return [None]
 
     symbols = [stocks.get_symbol_by_url(x) for x in data]

--- a/robin_stocks/options.py
+++ b/robin_stocks/options.py
@@ -1,7 +1,7 @@
 """Contains functions for getting information about options."""
+import sys
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
-import sys
 
 def spinning_cursor():
     """ This is a generator function to yield a character. """
@@ -13,11 +13,12 @@ spinner = spinning_cursor()
 
 def write_spinner():
     """ Function to create a spinning cursor to tell user that the code is working on getting market data. """
-    marketString = 'Loading Market Data '
-    sys.stdout.write(marketString)
-    sys.stdout.write(next(spinner))
-    sys.stdout.flush()
-    sys.stdout.write('\b'*(len(marketString)+1))
+    if helper.get_output()==sys.stdout:
+        marketString = 'Loading Market Data '
+        sys.stdout.write(marketString)
+        sys.stdout.write(next(spinner))
+        sys.stdout.flush()
+        sys.stdout.write('\b'*(len(marketString)+1))
 
 @helper.login_required
 def get_aggregate_positions(info=None):
@@ -96,7 +97,7 @@ def get_chains(symbol, info=None):
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     url = urls.chains(symbol)
@@ -125,12 +126,12 @@ def find_tradable_options(symbol, expirationDate=None, strikePrice=None, optionT
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     url = urls.option_instruments()
     if not helper.id_for_chain(symbol):
-        print("Symbol {} is not valid for finding options.".format(symbol))
+        print("Symbol {} is not valid for finding options.".format(symbol), file=helper.get_output())
         return [None]
 
     payload = {'chain_id': helper.id_for_chain(symbol),
@@ -168,7 +169,7 @@ def find_options_by_expiration(inputSymbols, expirationDate, optionType=None, in
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     data = []
@@ -206,7 +207,7 @@ def find_options_by_strike(inputSymbols, strikePrice, optionType=None, info=None
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     data = []
@@ -245,7 +246,7 @@ def find_options_by_expiration_and_strike(inputSymbols, expirationDate, strikePr
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     data = []
@@ -290,7 +291,7 @@ def find_options_by_specific_profitability(inputSymbols, expirationDate=None, st
     data = []
 
     if (typeProfit != "chance_of_profit_short" and typeProfit != "chance_of_profit_long"):
-        print("Invalid string for 'typeProfit'. Defaulting to 'chance_of_profit_short'.")
+        print("Invalid string for 'typeProfit'. Defaulting to 'chance_of_profit_short'.", file=helper.get_output())
         typeProfit = "chance_of_profit_short"
 
     for symbol in symbols:
@@ -386,7 +387,7 @@ def get_option_market_data(inputSymbols, expirationDate, strikePrice, optionType
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     data = []
@@ -435,7 +436,7 @@ def get_option_instrument_data(symbol, expirationDate, strikePrice, optionType, 
         symbol = symbol.upper().strip()
         optionType = optionType.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     optionID = helper.id_for_option(symbol, expirationDate, strikePrice, optionType)
@@ -473,7 +474,7 @@ def get_option_historicals(symbol, expirationDate, strikePrice, optionType, inte
         symbol = symbol.upper().strip()
         optionType = optionType.lower().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return [None]
 
     interval_check = ['5minute', '10minute', 'hour', 'day', 'week']
@@ -481,13 +482,13 @@ def get_option_historicals(symbol, expirationDate, strikePrice, optionType, inte
     bounds_check = ['extended', 'regular', 'trading']
     if interval not in interval_check:
         print(
-            'ERROR: Interval must be "5minute","10minute","hour","day",or "week"')
+            'ERROR: Interval must be "5minute","10minute","hour","day",or "week"', file=helper.get_output())
         return([None])
     if span not in span_check:
-        print('ERROR: Span must be "day", "week", "year", or "5year"')
+        print('ERROR: Span must be "day", "week", "year", or "5year"', file=helper.get_output())
         return([None])
     if bounds not in bounds_check:
-        print('ERROR: Bounds must be "extended","regular",or "trading"')
+        print('ERROR: Bounds must be "extended","regular",or "trading"', file=helper.get_output())
         return([None])
 
     optionID = helper.id_for_option(symbol, expirationDate, strikePrice, optionType)

--- a/robin_stocks/orders.py
+++ b/robin_stocks/orders.py
@@ -7,7 +7,6 @@ import robin_stocks.profiles as profiles
 import robin_stocks.stocks as stocks
 import robin_stocks.urls as urls
 
-
 @helper.login_required
 def get_all_stock_orders(info=None):
     """Returns a list of all the orders that have been processed for the account.
@@ -157,7 +156,7 @@ def find_stock_orders(**arguments):
     :type arguments: str
     :returns: Returns a list of orders.
 
-    """
+    """ 
     url = urls.orders()
     data = helper.request_get(url, 'pagination')
 
@@ -180,7 +179,7 @@ def find_stock_orders(**arguments):
     for item in data:
         for i, (key, value) in enumerate(arguments.items()):
             if key not in item:
-                print(helper.error_argument_not_key_in_dictionary(key))
+                print(helper.error_argument_not_key_in_dictionary(key), file=helper.get_output())
                 return([None])
             if value != item[key]:
                 break
@@ -198,12 +197,12 @@ def cancel_stock_order(orderID):
     :type orderID: str
     :returns: Returns the order information for the order that was cancelled.
 
-    """
+    """ 
     url = urls.cancel(orderID)
     data = helper.request_post(url)
 
     if data:
-        print('Order '+orderID+' cancelled')
+        print('Order '+orderID+' cancelled', file=helper.get_output())
     return(data)
 
 
@@ -215,12 +214,12 @@ def cancel_option_order(orderID):
     :type orderID: str
     :returns: Returns the order information for the order that was cancelled.
 
-    """
+    """ 
     url = urls.option_cancel(orderID)
     data = helper.request_post(url)
 
     if data:
-        print('Order '+orderID+' cancelled')
+        print('Order '+orderID+' cancelled', file=helper.get_output())
     return(data)
 
 
@@ -232,12 +231,12 @@ def cancel_crypto_order(orderID):
     :type orderID: str
     :returns: Returns the order information for the order that was cancelled.
 
-    """
+    """ 
     url = urls.crypto_cancel(orderID)
     data = helper.request_post(url)
 
     if data:
-        print('Order '+orderID+' cancelled')
+        print('Order '+orderID+' cancelled', file=helper.get_output())
     return(data)
 
 
@@ -247,7 +246,7 @@ def cancel_all_stock_orders():
 
     :returns: The list of orders that were cancelled.
 
-    """
+    """ 
     url = urls.orders()
     data = helper.request_get(url, 'pagination')
 
@@ -256,7 +255,7 @@ def cancel_all_stock_orders():
     for item in data:
         helper.request_post(item['cancel'])
 
-    print('All Stock Orders Cancelled')
+    print('All Stock Orders Cancelled', file=helper.get_output())
     return(data)
 
 
@@ -266,7 +265,7 @@ def cancel_all_option_orders():
 
     :returns: Returns the order information for the orders that were cancelled.
 
-    """
+    """ 
     url = urls.option_orders()
     data = helper.request_get(url, 'pagination')
 
@@ -275,7 +274,7 @@ def cancel_all_option_orders():
     for item in data:
         helper.request_post(item['cancel_url'])
 
-    print('All Option Orders Cancelled')
+    print('All Option Orders Cancelled', file=helper.get_output())
     return(data)
 
 
@@ -285,7 +284,7 @@ def cancel_all_crypto_orders():
 
     :returns: Returns the order information for the orders that were cancelled.
 
-    """
+    """ 
     url = urls.crypto_orders()
     data = helper.request_get(url, 'pagination')
 
@@ -294,7 +293,7 @@ def cancel_all_crypto_orders():
     for item in data:
         helper.request_post(item['cancel_url'])
 
-    print('All Crypto Orders Cancelled')
+    print('All Crypto Orders Cancelled', file=helper.get_output())
     return(data)
 
 
@@ -318,11 +317,11 @@ def order_buy_market(symbol, quantity, timeInForce='gtc', priceType='ask_price',
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     price = next(iter(stocks.get_latest_price(symbol, priceType, extendedHours)), 0.00)
@@ -369,11 +368,11 @@ def order_buy_fractional_by_quantity(symbol, quantity, timeInForce='gtc', priceT
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     price = next(iter(stocks.get_latest_price(symbol, priceType, extendedHours)), 0.00)
@@ -420,15 +419,15 @@ def order_buy_fractional_by_price(symbol, amountInDollars, timeInForce='gtc', pr
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     if amountInDollars < 1:
-        print("ERROR: Fractional share price should meet minimum 1.00.")
+        print("ERROR: Fractional share price should meet minimum 1.00.", file=helper.get_output())
         return None
 
     price = next(iter(stocks.get_latest_price(symbol, priceType, extendedHours)), 0.00)
@@ -479,12 +478,12 @@ def order_buy_limit(symbol, quantity, limitPrice, timeInForce='gtc', extendedHou
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
         limitPrice = helper.round_price(limitPrice)
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {
@@ -527,12 +526,12 @@ def order_buy_stop_loss(symbol, quantity, stopPrice, timeInForce='gtc', extended
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
         stopPrice = helper.round_price(stopPrice)
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {
@@ -577,13 +576,13 @@ def order_buy_stop_limit(symbol, quantity, limitPrice, stopPrice, timeInForce='g
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
         stopPrice = helper.round_price(stopPrice)
         limitPrice = helper.round_price(limitPrice)
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {
@@ -690,11 +689,11 @@ def order_sell_market(symbol, quantity, timeInForce='gtc', priceType='bid_price'
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     price = next(iter(stocks.get_latest_price(symbol, priceType, extendedHours)), 0.00)
@@ -738,11 +737,11 @@ def order_sell_fractional_by_quantity(symbol, quantity, timeInForce='gtc', price
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     price = next(iter(stocks.get_latest_price(symbol, priceType, extendedHours)), 0.00)
@@ -786,15 +785,15 @@ def order_sell_fractional_by_price(symbol, amountInDollars, timeInForce='gtc', p
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     if amountInDollars < 1:
-        print("ERROR: Fractional share price should meet minimum 1.00.")
+        print("ERROR: Fractional share price should meet minimum 1.00.", file=helper.get_output())
         return None
 
     price = next(iter(stocks.get_latest_price(symbol, priceType, extendedHours)), 0.00)
@@ -845,12 +844,12 @@ def order_sell_limit(symbol, quantity, limitPrice, timeInForce='gtc', extendedHo
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
         limitPrice = helper.round_price(limitPrice)
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {
@@ -893,12 +892,12 @@ def order_sell_stop_loss(symbol, quantity, stopPrice, timeInForce='gtc', extende
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
         stopPrice = helper.round_price(stopPrice)
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {
@@ -942,13 +941,13 @@ def order_sell_stop_limit(symbol, quantity, limitPrice, stopPrice, timeInForce='
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
         stopPrice = helper.round_price(stopPrice)
         limitPrice = helper.round_price(limitPrice)
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {
@@ -1002,11 +1001,11 @@ def order(symbol, quantity, orderType, trigger, side, priceType=None, limitPrice
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     if stopPrice:
@@ -1121,11 +1120,11 @@ def order_option_spread(direction, price, symbol, quantity, spread, timeInForce=
     :returns: Dictionary that contains information regarding the trading of options, \
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
     legs = []
     for each in spread:
@@ -1185,11 +1184,11 @@ def order_buy_option_limit(positionEffect, creditOrDebit, price, symbol, quantit
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     optionID = helper.id_for_option(symbol, expirationDate, strike, optionType)
@@ -1246,11 +1245,11 @@ def order_buy_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stopP
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     optionID = helper.id_for_option(symbol, expirationDate, strike, optionType)
@@ -1307,11 +1306,11 @@ def order_sell_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stop
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     optionID = helper.id_for_option(symbol, expirationDate, strike, optionType)
@@ -1371,7 +1370,7 @@ def order_sell_option_limit(positionEffect, creditOrDebit, price, symbol, quanti
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     optionID = helper.id_for_option(symbol, expirationDate, strike, optionType)
@@ -1417,11 +1416,11 @@ def order_buy_crypto_by_price(symbol, amountInDollars, priceType='ask_price', ti
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     crypto_info = crypto.get_crypto_info(symbol)
@@ -1467,11 +1466,11 @@ def order_buy_crypto_by_quantity(symbol, quantity, priceType='ask_price', timeIn
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     crypto_info = crypto.get_crypto_info(symbol)
@@ -1513,17 +1512,17 @@ def order_buy_crypto_limit(symbol, quantity, price, timeInForce='gtc'):
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     crypto_info = crypto.get_crypto_info(symbol)
 
     if crypto_info['display_only']:
-        print("WARNING: The dictionary returned by crypto.get_crypto_info() for this crypto has key 'display_only' set to True. May not be able to trade this crypto.")
+        print("WARNING: The dictionary returned by crypto.get_crypto_info() for this crypto has key 'display_only' set to True. May not be able to trade this crypto.", file=helper.get_output())
 
     payload = {
         'account_id': crypto.load_crypto_profile(info="id"),
@@ -1560,11 +1559,11 @@ def order_sell_crypto_by_price(symbol, amountInDollars, priceType='bid_price', t
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     crypto_info = crypto.get_crypto_info(symbol)
@@ -1611,11 +1610,11 @@ def order_sell_crypto_by_quantity(symbol, quantity, priceType='bid_price', timeI
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     crypto_info = crypto.get_crypto_info(symbol)
@@ -1661,13 +1660,13 @@ def order_sell_crypto_limit(symbol, quantity, price, timeInForce='gtc'):
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     crypto_info = crypto.get_crypto_info(symbol)
 
     if crypto_info['display_only']:
-        print("WARNING: The dictionary returned by crypto.get_crypto_info() for this crypto has key 'display_only' set to True. May not be able to trade this crypto.")
+        print("WARNING: The dictionary returned by crypto.get_crypto_info() for this crypto has key 'display_only' set to True. May not be able to trade this crypto.", file=helper.get_output())
 
     payload = {
         'account_id': crypto.load_crypto_profile(info="id"),

--- a/robin_stocks/stocks.py
+++ b/robin_stocks/stocks.py
@@ -2,7 +2,6 @@
 import robin_stocks.helper as helper
 import robin_stocks.urls as urls
 
-
 def get_quotes(inputSymbols, info=None):
     """Takes any number of stock tickers and returns information pertaining to its price.
 
@@ -39,7 +38,7 @@ def get_quotes(inputSymbols, info=None):
 
     for count, item in enumerate(data):
         if item is None:
-            print(helper.error_ticker_does_not_exist(symbols[count]))
+            print(helper.error_ticker_does_not_exist(symbols[count]), file=helper.get_output())
 
     data = [item for item in data if item is not None]
 
@@ -81,7 +80,7 @@ def get_fundamentals(inputSymbols, info=None):
                       * year_founded
                       * symbol
 
-    """
+    """ 
     symbols = helper.inputs_to_set(inputSymbols)
     url = urls.fundamentals()
     payload = {'symbols': ','.join(symbols)}
@@ -92,7 +91,7 @@ def get_fundamentals(inputSymbols, info=None):
 
     for count, item in enumerate(data):
         if item is None:
-            print(helper.error_ticker_does_not_exist(symbols[count]))
+            print(helper.error_ticker_does_not_exist(symbols[count]), file=helper.get_output())
         else:
             item['symbol'] = symbols[count]
 
@@ -136,7 +135,7 @@ def get_instruments_by_symbols(inputSymbols, info=None):
                       * fractional_tradability
                       * default_collar_fraction
 
-    """
+    """ 
     symbols = helper.inputs_to_set(inputSymbols)
     url = urls.instruments()
     data = []
@@ -147,7 +146,7 @@ def get_instruments_by_symbols(inputSymbols, info=None):
         if itemData:
             data.append(itemData)
         else:
-            print(helper.error_ticker_does_not_exist(item))
+            print(helper.error_ticker_does_not_exist(item), file=helper.get_output())
 
     return(helper.filter(data, info))
 
@@ -206,7 +205,7 @@ def get_latest_price(inputSymbols, priceType=None, includeExtendedHours=True):
     :type includeExtendedHours: bool
     :returns: [list] A list of prices as strings.
 
-    """
+    """ 
     symbols = helper.inputs_to_set(inputSymbols)
     quote = get_quotes(symbols)
 
@@ -219,7 +218,7 @@ def get_latest_price(inputSymbols, priceType=None, includeExtendedHours=True):
                 prices.append(item['bid_price'])
             else:
                 if priceType:
-                    print('WARNING: priceType should be "ask_price" or "bid_price". You entered "{0}"'.format(priceType))
+                    print('WARNING: priceType should be "ask_price" or "bid_price". You entered "{0}"'.format(priceType), file=helper.get_output())
                 if item['last_extended_hours_trade_price'] is None or not includeExtendedHours:
                     prices.append(item['last_trade_price'])
                 else:
@@ -237,11 +236,11 @@ def get_name_by_symbol(symbol):
     :type symbol: str
     :returns: [str] Returns the simple name of the stock. If the simple name does not exist then returns the full name.
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     url = urls.instruments()
@@ -305,11 +304,11 @@ def get_ratings(symbol, info=None):
                       * instrument_id - value is a string
                       * ratings_published_at - value is a string
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     url = urls.ratings(symbol)
@@ -355,11 +354,11 @@ def get_events(symbol, info=None):
                       * underlying_price
                       * updated_at
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     payload = {'equity_instrument_id': helper.id_for_stock(symbol)}
@@ -387,11 +386,11 @@ def get_earnings(symbol, info=None):
                       * report
                       * call
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     url = urls.earnings()
@@ -427,11 +426,11 @@ def get_news(symbol, info=None):
                       * preview_text
                       * currency_id
 
-    """
+    """ 
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     url = urls.news(symbol)
@@ -461,7 +460,7 @@ def get_splits(symbol, info=None):
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
-        print(message)
+        print(message, file=helper.get_output())
         return None
 
     url = urls.splits(symbol)
@@ -500,17 +499,17 @@ def find_instrument_data(query):
                       * fractional_tradability
                       * default_collar_fraction
 
-    """
+    """ 
     url = urls.instruments()
     payload = {'query': query}
 
     data = helper.request_get(url, 'pagination', payload)
 
     if len(data) == 0:
-        print('No results found for that keyword')
+        print('No results found for that keyword', file=helper.get_output())
         return([None])
     else:
-        print('Found ' + str(len(data)) + ' results')
+        print('Found ' + str(len(data)) + ' results', file=helper.get_output())
         return(data)
 
 
@@ -539,23 +538,23 @@ def get_stock_historicals(inputSymbols, interval='hour', span='week', bounds='re
                       * interpolated
                       * symbol
 
-    """
+    """    
     interval_check = ['5minute', '10minute', 'hour', 'day', 'week']
     span_check = ['day', 'week', 'month', '3month', 'year', '5year']
     bounds_check = ['extended', 'regular', 'trading']
 
     if interval not in interval_check:
         print(
-            'ERROR: Interval must be "5minute","10minute","hour","day",or "week"')
+            'ERROR: Interval must be "5minute","10minute","hour","day",or "week"', file=helper.get_output())
         return([None])
     if span not in span_check:
-        print('ERROR: Span must be "day","week","month","3month","year",or "5year"')
+        print('ERROR: Span must be "day","week","month","3month","year",or "5year"', file=helper.get_output())
         return([None])
     if bounds not in bounds_check:
-        print('ERROR: Bounds must be "extended","regular",or "trading"')
+        print('ERROR: Bounds must be "extended","regular",or "trading"', file=helper.get_output())
         return([None])
     if (bounds == 'extended' or bounds == 'trading') and span != 'day':
-        print('ERROR: extended and trading bounds can only be used with a span of "day"')
+        print('ERROR: extended and trading bounds can only be used with a span of "day"', file=helper.get_output())
         return([None])
 
     symbols = helper.inputs_to_set(inputSymbols)
@@ -572,7 +571,7 @@ def get_stock_historicals(inputSymbols, interval='hour', span='week', bounds='re
     histData = []
     for count, item in enumerate(data):
         if (len(item['historicals']) == 0):
-            print(helper.error_ticker_does_not_exist(symbols[count]))
+            print(helper.error_ticker_does_not_exist(symbols[count]), file=helper.get_output())
             continue
         stockSymbol = item['symbol']
         for subitem in item['historicals']:


### PR DESCRIPTION
This goes with Issue #119 - I had free time today, so I put together
and option on how to do it.

Rather than always outputting to stdout, I added a new set_output
and get_output in helper.py that allows the client to set the stream
that all print statements will go to.  It defaults to stdout so the
standard behavior should remain unchanged.

Rather than pass this around everywhere, I made the stream a global.
I stayed with the default print() function and just passed in the
stream with the file= keyword.  It may have made more sense to create
a new print function wrapper. So that the file= logic is in one place

The other controversial part is the write_spinner function.  I did the
simple approach to do the spinner only if the output is equal to stdout.
Otherwise the spinner is ignored.  I think that's fine for most use
cases.  I could see a case where a unix user is redirecting the
output of to a file, In that case, the stdout check will pass and all
of the \b will be put into the file.  It probably makes more sense to
do the spinner only if we're going to a terminal, but I'm not going
that far.