### PR TITLE
Fixed find_options_by_specific_profitability

### DIFF
--- a/robin_stocks/options.py
+++ b/robin_stocks/options.py
@@ -301,15 +301,17 @@ def find_options_by_specific_profitability(inputSymbols, expirationDate=None, st
                 continue
 
             market_data = get_option_market_data_by_id(option['id'])
-            option.update(market_data[0])
-            write_spinner()
+            
+            if len(market_data):
+                option.update(market_data[0])
+                write_spinner()
 
-            try:
-                floatValue = float(option[typeProfit])
-                if (floatValue >= profitFloor and floatValue <= profitCeiling):
-                    data.append(option)
-            except:
-                pass
+                try:
+                    floatValue = float(option[typeProfit])
+                    if (floatValue >= profitFloor and floatValue <= profitCeiling):
+                        data.append(option)
+                except:
+                    pass
 
     return(helper.filter(data, info))
 


### PR DESCRIPTION
find_options_by_specific_profitability will fail if an empty list is returned by get_option_market_data_by_id. Added a check for empty list.