### PR TITLE
fixed order_crypto recursive call

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -1439,7 +1439,7 @@ def order_crypto(symbol, side, quantityOrPrice, amountIn="quantity", limitPrice=
         'type': orderType
     }
 
-    url = order_crypto()
+    url = crypto_order()
     data = request_post(url, payload, json=True, jsonify_data=jsonify)
 
     return(data)

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -232,7 +232,7 @@ def marketdata_pricebook(id):
 # crypto
 
 
-def order_crypto():
+def crypto_order():
     return('https://nummus.robinhood.com/orders/')
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='2.0.2',
+      version='2.0.21',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/x-rst',


### PR DESCRIPTION
PR addressing issue here: https://github.com/jmfernandes/robin_stocks/issues/254


I changed the url getter function in "robinhood/urls" from "order_crypto" to "crypto_order" so that it wouldn't conflict with the "order_crypto" method in "robinhood/orders".

