### PR TITLE
Make crypto orders more reliable

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -1440,6 +1440,14 @@ def order_crypto(symbol, side, quantityOrPrice, amountIn="quantity", limitPrice=
     }
 
     url = order_crypto_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+
+    # This is safe because 'ref_id' guards us from duplicate orders
+    attempts = 3
+    while attempts > 0:
+        data = request_post(url, payload, json=True, jsonify_data=jsonify)
+        if data is not None:
+            break
+
+        attempts -= 1
 
     return(data)


### PR DESCRIPTION
Every once in a while, I'll get errors like this:
```
Error in request_post: HTTPSConnectionPool(host='nummus.robinhood.com', port=443): Read timed out. (read timeout=16)
```

I'm hoping retrying the request a few times will be enough to have it go through. If this isn't the desired fix, then `ref_id` needs to be a param we can control so we can write our own retry logic.