### PR TITLE
Incorrect verification when reusing pickled authentication

### DIFF
--- a/robin_stocks/robinhood/authentication.py
+++ b/robin_stocks/robinhood/authentication.py
@@ -125,7 +125,7 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', by_sm
                         'Authorization', '{0} {1}'.format(token_type, access_token))
                     # Try to load account profile to check that authorization token is still valid.
                     res = request_get(
-                        portfolio_profile_url(), 'regular', payload, jsonify_data=False)
+                        portfolio_profile_url(), 'regular', {}, jsonify_data=False)
                     # Raises exception is response code is not 200.
                     res.raise_for_status()
                     return({'access_token': access_token, 'token_type': token_type,


### PR DESCRIPTION
As mentioned in Issue #311, the current `login` doesn't correctly verifies the authentication when recovering from a pickled session. By testing I realize that the issue is from `payload['password']`. After successfully recovered from the pickled session, passing a password (even the correct one) to get portfolio profile somehow results in 401.

In this PR, I instead pass an empty payload to `request_get()` and check if it returns 200. In my test cases it works well. 