### PR TITLE
Add md5 to pickle filename

### DIFF
--- a/robin_stocks/robinhood/authentication.py
+++ b/robin_stocks/robinhood/authentication.py
@@ -3,6 +3,7 @@ import getpass
 import os
 import pickle
 import random
+import hashlib
 
 from robin_stocks.robinhood.helper import *
 from robin_stocks.robinhood.urls import *
@@ -82,7 +83,7 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', by_sm
     data_dir = os.path.join(home_dir, ".tokens")
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
-    creds_file = "robinhood.pickle"
+    creds_file = hashlib.md5(username.encode()).hexdigest()+".robinhood.pickle"
     pickle_path = os.path.join(data_dir, creds_file)
     # Challenge type is used if not logging in with two-factor authentication.
     if by_sms:


### PR DESCRIPTION
As mentioned in my comment under Issue #208, by simply adding MD5 of username to pickle filename, you can log in to different accounts on the same machine/environment and have sessions stored independently in different pickle files.

Theoretically, MD5 may collide, but I don't believe any personal usernames used by the small group would MD5 collide. I think this is a simple but useful thing to add to the current code. 
