### PR TITLE
Update options.py, prevent extra call to request_get in get_option_market_data_by_id()

### DIFF
--- a/robin_stocks/robinhood/options.py
+++ b/robin_stocks/robinhood/options.py
@@ -331,10 +331,9 @@ def get_option_market_data_by_id(id, info=None):
     If info parameter is provided, the value of the key that matches info is extracted.
 
     """
-    instrument = get_option_instrument_data_by_id(id)
     url = marketdata_options_url()
     payload = {
-        "instruments" : instrument['url']
+        "instruments" : option_instruments_url(id)
     }
     data = request_get(url, 'results', payload)
 


### PR DESCRIPTION
Prevents an extra call to request_get to get the instrument url, uses option_instruments_url() function and id to generate instead.