### PR TITLE
Caching constant output of stocks helper functions.

### DIFF
--- a/robin_stocks/robinhood/stocks.py
+++ b/robin_stocks/robinhood/stocks.py
@@ -1,4 +1,6 @@
 """Contains information in regards to stocks."""
+from functools import cache
+
 from robin_stocks.robinhood.helper import *
 from robin_stocks.robinhood.urls import *
 
@@ -227,7 +229,7 @@ def get_latest_price(inputSymbols, priceType=None, includeExtendedHours=True):
             prices.append(None)
     return(prices)
 
-
+@cache
 @convert_none_to_string
 def get_name_by_symbol(symbol):
     """Returns the name of a stock from the stock ticker.
@@ -255,6 +257,7 @@ def get_name_by_symbol(symbol):
     return(filter)
 
 
+@cache
 @convert_none_to_string
 def get_name_by_url(url):
     """Returns the name of a stock from the instrument url. Should be located at ``https://api.robinhood.com/instruments/<id>``
@@ -275,6 +278,7 @@ def get_name_by_url(url):
     return(filter)
 
 
+@cache
 @convert_none_to_string
 def get_symbol_by_url(url):
     """Returns the symbol of a stock from the instrument url. Should be located at ``https://api.robinhood.com/instruments/<id>``


### PR DESCRIPTION
Added caching to three helper functions in stocks module using `cache` decorator from `functools`. These function return a fixed value for a given input. When exporting stocks info they may get called hundreds of times, most of which may be repeated calls for the same stock. Below is timings for export calls for my Robinhood account before (33.4s) and after (6.61s) caching. Similar times observed in multiple runs.

~This test~ Below run only involves `get_symbol_by_url` call. Tests are not changed as test calls to functions wrapped with caching exist.


```
/Documents/GitHub/robin_stocks (master) » ipython                                                                                                          ahmet@Merves-MacBook-Pro
Python 3.9.9 (main, Dec 29 2021, 15:49:43)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import robin_stocks.robinhood as robinhood
   ...: login = robinhood.login('***,'')

In [2]: %time robinhood.export_completed_stock_orders('.')
Found Additional pages.
Loading page 2 ...
Loading page 3 ...
Loading page 4 ...
CPU times: user 975 ms, sys: 144 ms, total: 1.12 s
Wall time: 33.4 s

In [3]:
Do you really want to exit ([y]/n)?
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/Documents/GitHub/robin_stocks (master*) » git checkout cache
Switched to branch 'cache'
Your branch is up to date with 'origin/cache'.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/Documents/GitHub/robin_stocks (cache*) » ipython                                                                                                          
Python 3.9.9 (main, Dec 29 2021, 15:49:43)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import robin_stocks.robinhood as robinhood
   ...: login = robinhood.login('***','')

In [2]: %time robinhood.export_completed_stock_orders('.')
Found Additional pages.
Loading page 2 ...
Loading page 3 ...
Loading page 4 ...
CPU times: user 197 ms, sys: 30.2 ms, total: 227 ms
Wall time: 6.61 s
```