### PR TITLE
Fix incidental quantity flooring 

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -164,7 +164,8 @@ def find_stock_orders(**arguments):
         return(data)
 
     for item in data:
-        item['quantity'] = str(int(float(item['quantity'])))
+        item['quantity'] = str(float(item['quantity']))
+        item['cumulative_quantity'] = str(float(item['cumulative_quantity']))
 
     if 'symbol' in arguments.keys():
         arguments['instrument'] = get_instruments_by_symbols(

--- a/tests/test_robinhood.py
+++ b/tests/test_robinhood.py
@@ -814,3 +814,26 @@ class TestProfiles:
         r.logout()
         profile = r.load_account_profile(info=None)
         assert profile
+
+class TestOrders:
+    @classmethod
+    def setup_class(cls):
+        totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
+        login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+    
+    def test_find_stock_orders(cls):
+        def isFloat(f):
+            try:
+                float(f)
+                return True
+            except ValueError:
+                return False
+
+        orderHistory = r.find_stock_orders()
+        assert orderHistory
+
+        for order in orderHistory:
+            assert isFloat(order['quantity'])
+            assert isFloat(order['cumulative_quantity'])
+            if(order['state'] == 'filled'):
+                assert (order['quantity'] == order['cumulative_quantity'])


### PR DESCRIPTION
fix flooring of order quantity value in the case of fractional shares

add test for find_stock_orders() changes

[issue](https://github.com/jmfernandes/robin_stocks/issues/339)
#339 