### PR TITLE
`ratio_quantity` in `orders.order_option_spread`

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -928,7 +928,7 @@ def order_option_spread(direction, price, symbol, quantity, spread, timeInForce=
                                         each['optionType'])
         legs.append({'position_effect': each['effect'],
                      'side': each['action'],
-                     'ratio_quantity': 1,
+                     'ratio_quantity': each.get('ratio_quantity', default=1),
                      'option': option_instruments_url(optionID)})
 
     payload = {


### PR DESCRIPTION
Control ratio quantity by adding `"ratio_quantity": n` to dict in `spread`. Defaults to 1, so it's non-breaking
closes #355 