### PR TITLE
add sell by id functionality

### DIFF
--- a/robin_stocks/robinhood/__init__.py
+++ b/robin_stocks/robinhood/__init__.py
@@ -60,9 +60,10 @@ from .orders import (cancel_all_crypto_orders, cancel_all_option_orders,
                      order_sell_crypto_limit, order_sell_crypto_limit_by_price,
                      order_sell_fractional_by_price,
                      order_sell_fractional_by_quantity, order_sell_limit,
-                     order_sell_market, order_sell_option_limit,
-                     order_sell_option_stop_limit, order_sell_stop_limit,
-                     order_sell_stop_loss, order_sell_trailing_stop)
+                     order_sell_market, order_sell_option_limit, 
+                     order_sell_option_limit_by_id, order_sell_option_stop_limit,
+                     order_sell_stop_limit, order_sell_stop_loss,
+                     order_sell_trailing_stop)
 from .profiles import (load_account_profile, load_basic_profile,
                        load_investment_profile, load_portfolio_profile,
                        load_security_profile, load_user_profile)

--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -1140,6 +1140,51 @@ def order_sell_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stop
 
 
 @login_required
+def order_sell_option_limit_by_id(positionEffect, creditOrDebit, price, quantity, optionID, timeInForce='gtc', jsonify=True):
+    """Submits a limit order for an option by its ID. i.e. place a short call or a short put.
+
+    :param positionEffect: Either 'open' for a sell to open effect or 'close' for a sell to close effect.
+    :type positionEffect: str
+    :param creditOrDebit: Either 'debit' or 'credit'.
+    :type creditOrDebit: str
+    :param price: The limit price to trigger a sell of the option.
+    :type price: float
+    :param quantity: The number of options to sell.
+    :type quantity: int
+    :param timeInForce: Changes how long the order will be in effect for. 'gtc' = good until cancelled. \
+    'gfd' = good for the day. 'ioc' = immediate or cancel. 'opg' execute at opening.
+    :type timeInForce: Optional[str]
+    :param jsonify: If set to False, function will return the request object which contains status code and headers.
+    :type jsonify: Optional[str]
+    :returns: Dictionary that contains information regarding the selling of options, \
+    such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
+    the price, and the quantity.
+
+    """
+    payload = {
+        'account': load_account_profile(info='url'),
+        'direction': creditOrDebit,
+        'time_in_force': timeInForce,
+        'legs': [
+            {'position_effect': positionEffect, 'side': 'sell',
+                'ratio_quantity': 1, 'option': option_instruments_url(optionID)},
+        ],
+        'type': 'limit',
+        'trigger': 'immediate',
+        'price': price,
+        'quantity': quantity,
+        'override_day_trade_checks': False,
+        'override_dtbp_checks': False,
+        'ref_id': str(uuid4()),
+    }
+
+    url = option_orders_url()
+    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+
+    return(data)
+
+
+@login_required
 def order_sell_option_limit(positionEffect, creditOrDebit, price, symbol, quantity, expirationDate, strike, optionType='both', timeInForce='gtc', jsonify=True):
     """Submits a limit order for an option. i.e. place a short call or a short put.
 


### PR DESCRIPTION
Right now we can't sell an option by its ID. If this is accepted, I will add this feature for the stop sell as well. Is this repo still active, or is there a different fork we should consider pointing to instead?