### PR TITLE
order_buy_fractional_by_price Patch

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -378,30 +378,7 @@ def order_buy_fractional_by_price(symbol, amountInDollars, account_number=None, 
     price = next(iter(get_latest_price(symbol, 'ask_price', extendedHours)), 0.00)
     fractional_shares = 0 if (price == 0.00) else round_price(amountInDollars/float(price))
     
-    ### BEGIN: Patch for new Robinhood Order Form (GuitarGuyChrisB 5/25/2023)
-    # return order(symbol, fractional_shares, "buy", account_number, None, None, timeInForce, extendedHours, jsonify)
-
-    payload = {
-        'account': load_account_profile(account_number=account_number, info='url'),
-        'instrument': get_instruments_by_symbols(symbol, info='url')[0],
-        'order_form_version': "2",
-        'preset_percent_limit': "0.05",
-        'symbol': symbol,
-        'price': price,
-        'quantity': fractional_shares,
-        'ref_id': str(uuid4()),
-        'type': "limit",
-        'time_in_force': timeInForce,
-        'trigger': "immediate",
-        'side': "buy",
-        'extended_hours': extendedHours
-    }
-
-    url = orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
-
-    return (data)
-    ### END: Patch for new Robinhood Order Form (GuitarGuyChrisB 5/25/2023)
+    return order(symbol, fractional_shares, "buy", account_number, None, None, timeInForce, extendedHours, jsonify)
 
 
 @login_required
@@ -850,6 +827,11 @@ def order(symbol, quantity, side, account_number=None, limitPrice=None, stopPric
         'side': side,
         'extended_hours': extendedHours
     }
+    # BEGIN PATCH FOR NEW ROBINHOOD BUY FORM (GuitarGuyChrisB 5/26/2023)
+    if side == "buy":
+        payload['order_form_version'] = "2"
+        payload['preset_percent_limit'] = "0.05"
+    # END PATCH FOR NEW ROBINHOOD BUY FORM (GuitarGuyChrisB 5/26/2023)
 
     url = orders_url()
 

--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -377,8 +377,31 @@ def order_buy_fractional_by_price(symbol, amountInDollars, account_number=None, 
     # turn the money amount into decimal number of shares
     price = next(iter(get_latest_price(symbol, 'ask_price', extendedHours)), 0.00)
     fractional_shares = 0 if (price == 0.00) else round_price(amountInDollars/float(price))
+    
+    ### BEGIN: Patch for new Robinhood Order Form (GuitarGuyChrisB 5/25/2023)
+    # return order(symbol, fractional_shares, "buy", account_number, None, None, timeInForce, extendedHours, jsonify)
 
-    return order(symbol, fractional_shares, "buy", account_number, None, None, timeInForce, extendedHours, jsonify)
+    payload = {
+        'account': load_account_profile(account_number=account_number, info='url'),
+        'instrument': get_instruments_by_symbols(symbol, info='url')[0],
+        'order_form_version': "2",
+        'preset_percent_limit': "0.05",
+        'symbol': symbol,
+        'price': price,
+        'quantity': fractional_shares,
+        'ref_id': str(uuid4()),
+        'type': "limit",
+        'time_in_force': timeInForce,
+        'trigger': "immediate",
+        'side': "buy",
+        'extended_hours': extendedHours
+    }
+
+    url = orders_url()
+    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+
+    return (data)
+    ### END: Patch for new Robinhood Order Form (GuitarGuyChrisB 5/25/2023)
 
 
 @login_required

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='3.0.0',
+      version='3.0.1',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/x-rst',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='3.0.1',
+      version='3.0.2',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/x-rst',


### PR DESCRIPTION
Updated the order_buy_fractional_by_price() function to incorporate changes by @scurt8 to accommodate Robinhood's new order form format. This was causing a "Your app version is missing important stock trading updates. You can still place orders on the web." response from Robinhood when submitting an order for fractional shares.