### PR TITLE
Update orders.py to fix "ValueError: could not convert string to float: 'gtc'

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -318,7 +318,7 @@ def order_buy_market(symbol, quantity, timeInForce='gtc', extendedHours=False, j
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", None, None, timeInForce, extendedHours, jsonify)
+    return order(symbol, quantity, "buy", None, None, None, timeInForce, extendedHours, jsonify)
 
 
 @login_required


### PR DESCRIPTION
This is to fix the "ValueError: could not convert string to float: 'gtc'" error.  

This is to address issue #394.