### PR TITLE
Update orders.py

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -813,6 +813,7 @@ def order(symbol, quantity, side, limitPrice=None, stopPrice=None, account_numbe
 
     if side == "buy":
         priceType = "ask_price"
+        orderType = 'limit'
     else:
         priceType = "bid_price"
 


### PR DESCRIPTION
quick fix for 'Invalid market order' not allowing market as order type