### PR TITLE
Corrected option_positions_url

### DIFF
--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -221,7 +221,7 @@ def option_orders_url(orderID=None, account_number=None):
     return url
 
 
-def option_positions_url(account_number):
+def option_positions_url(account_number=None):
     if account_number:
         return('https://api.robinhood.com/options/positions/?account_numbers='+account_number)
     else:


### PR DESCRIPTION
Corrected option_positions_url to allow a null account_number as intended by original dev

Fixes #431 