### PR TITLE
Refactored method calls and replaced positional arguments with keyword arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Below are examples on how to call each of those modules.
 >>> import robin_stocks.gemini as gem
 >>> import robin_stocks.tda as tda
 >>> # Here are some example calls
->>> gem.get_pubticker("btcusd") # gets ticker information for Bitcoin from Gemini
+>>> gem.get_pubticker(ticker="btcusd") # gets ticker information for Bitcoin from Gemini
 >>> rh.get_all_open_crypto_orders() # gets all cypto orders from Robinhood
 >>> tda.get_price_history("tsla") # get price history from TD Ameritrade 
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Below are examples on how to call each of those modules.
 >>> # Here are some example calls
 >>> gem.get_pubticker(ticker="btcusd") # gets ticker information for Bitcoin from Gemini
 >>> rh.get_all_open_crypto_orders() # gets all cypto orders from Robinhood
->>> tda.get_price_history("tsla") # get price history from TD Ameritrade 
+>>> tda.get_price_history(ticker="tsla") # get price history from TD Ameritrade
 
 Contributing
 ============

--- a/Robinhood.rst
+++ b/Robinhood.rst
@@ -8,7 +8,7 @@ Basic
 ^^^^^
 
 >>> import robin_stocks.robinhood as r
->>> login = r.login('joshsmith@email.com','password')
+>>> login = r.login(username='joshsmith@email.com',password='password')
 
 You will be prompted for your MFA token if you have MFA enabled and choose to do the above basic example.
 
@@ -34,7 +34,7 @@ Now you should be able to login with the following code,
 >>> import pyotp
 >>> import robin_stocks.robinhood as r
 >>> totp  = pyotp.TOTP("My2factorAppHere").now()
->>> login = r.login('joshsmith@email.com','password', mfa_code=totp)
+>>> login = r.login(username='joshsmith@email.com', password='password', mfa_code=totp)
 
 Not all of the functions contained in the module need the user to be authenticated. A lot of the functions
 contained in the modules 'stocks' and 'options' do not require authentication, but it's still good practice
@@ -48,13 +48,13 @@ There is also the ability to submit market orders, limit orders, and stop orders
 Robinhood supports it. Here is a list of possible trades you can make
 
 >>> #Buy 10 shares of Apple at market price
->>> r.order_buy_market('AAPL',10)
+>>> r.order_buy_market(symbol='AAPL',quantity=10)
 >>> #Sell half a Bitcoin is price reaches 10,000
->>> r.order_sell_crypto_limit('BTC',0.5,10000)
+>>> r.order_sell_crypto_limit(symbol='BTC', quantity=0.5, limitPrice=10000)
 >>> #Buy $500 worth of Bitcoin
->>> r.order_buy_crypto_by_price('BTC',500)
+>>> r.order_buy_crypto_by_price(symbol='BTC', amountInDollars=500)
 >>> #Buy 5 $150 May 1st, 2020 SPY puts if the price per contract is $1.00. Good until cancelled.
->>> r.order_buy_option_limit('open','debit',1.00,'SPY',5,'2020-05-01',150,'put','gtc')
+>>> r.order_buy_option_limit(positionEffect='open',creditOrDebit='debit',price=1.00,symbol='SPY',quantity=5,expirationDate='2020-05-01',strike=150,optionType='put',timeInForce='gtc')
 
 Now let's try a slightly more complex example. Let's say you wanted to sell half your Tesla stock if it fell to 200.00.
 To do this you would type
@@ -64,10 +64,10 @@ To do this you would type
 >>> ## does not provide that information in the stock orders.
 >>> ## This process is very slow since it is making a GET request for each order.
 >>> for item in positions_data:
->>>     item['symbol'] = r.get_symbol_by_url(item['instrument'])
+>>>     item['symbol'] = r.get_symbol_by_url(url=item['instrument'])
 >>> TSLAData = [item for item in positions_data if item['symbol'] == 'TSLA']
 >>> sellQuantity = float(TSLAData['quantity'])//2.0
->>> r.order_sell_limit('TSLA',sellQuantity,200.00)
+>>> r.order_sell_limit(symbol='TSLA', quantity=sellQuantity, limitPrice=200.00)
 
 Viewing Orders
 --------------
@@ -81,14 +81,14 @@ If you want to cancel all your limit sells, you would type
 >>> ## Note: Again we are adding symbol to our list of orders because Robinhood
 >>> ## does not include this with the order information.
 >>> for item in positions_data:
->>>    item['symbol'] = r.get_crypto_quote_from_id(item['currency_pair_id'], 'symbol')
+>>>    item['symbol'] = r.get_crypto_quote_from_id(id=item['currency_pair_id'], info='symbol')
 >>> btcOrders = [item for item in positions_data if item['symbol'] == 'BTCUSD' and item['side'] == 'sell']
 >>> for item in btcOrders:
->>>    r.cancel_crypto_order(item['id'])
+>>>    r.cancel_crypto_order(orderId=item['id'])
 
 If you want to view all the call options for a list of stocks you could type
 
->>> optionData = r.find_options_by_expiration(['fb','aapl','tsla','nflx'],
+>>> optionData = r.find_options_by_expiration(inputSymbols=['fb','aapl','tsla','nflx'],
 >>>              expirationDate='2018-11-16',optionType='call')
 >>> for item in optionData:
 >>>     print(' price -',item['strike_price'],' exp - ',item['expiration_date'],' symbol - ',
@@ -107,7 +107,7 @@ exposed the get and post methods so any call to the Robinhood API could be made.
 
 >>> url = 'https://api.robinhood.com/'
 >>> payload = { 'key1' : 'value1', 'key2' : 'value2'}
->>> r.request_get(url,'regular',payload)
+>>> r.request_get(url=url, dataType='regular', payload=payload)
 
 The above code would results in a get request to ``https://api.robinhood.com/?key1=value1&key2=value2`` (which is a
 meaningless request). RobinHood returns most data as { 'previous' : None, 'results' : [], 'next' : None},
@@ -125,16 +125,16 @@ can be either absolute or relative. To save the file in the current directory, s
 file extension. If it is missing it will be added, and any other file extension will be automatically changed. Below are example calls.
 
 >>> # let's say that I am running code from C:/Users/josh/documents/
->>> r.export_completed_stock_orders(".") # saves at C:/Users/josh/documents/stock_orders_Jun-28-2020.csv
->>> r.export_completed_option_orders("../", "toplevel") # save at C:/Users/josh/toplevel.csv
+>>> r.export_completed_stock_orders(dir_path=".") # saves at C:/Users/josh/documents/stock_orders_Jun-28-2020.csv
+>>> r.export_completed_option_orders(dir_path="../", file_name="toplevel") # save at C:/Users/josh/toplevel.csv
 
 Getting Quote Information For Stocks In A Specific Category
 -----------------------------------------------------------
 When you are on Robinhood, there are these green tags you can click on to get all the stocks for that category.
 You can now get the quote information for those categories by calling
 
->>> r.get_all_stocks_from_market_tag('upcoming-earnings') # get upcoming earnings
->>> r.get_all_stocks_from_market_tag('technology') # get all tech tags
+>>> r.get_all_stocks_from_market_tag(tag='upcoming-earnings') # get upcoming earnings
+>>> r.get_all_stocks_from_market_tag(tag='technology') # get all tech tags
 
 These functions do some processing to get the quote data so they may run a little slow.
 The Robinhood API only returns a list of instrument urls.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -16,7 +16,7 @@ get request to the option instruments API endpoint in order to get all calls you
 
 >>> url = 'https://api.robinhood.com/options/instruments/'
 >>> payload = { 'type' : 'call'}
->>> robin_stocks.request_get(url,'regular',payload)
+>>> robin_stocks.request_get(url=url, dataType='regular', payload=payload)
 
 Robinhood returns most data in the form::
 
@@ -27,20 +27,20 @@ Robinhood returns the data in a different format. To compensate for this, I adde
 the **dataType** parameter which defaults to return the entire dictionary listed above.
 There are four possible values for **dataType** and their uses are:
 
->>> robin_stocks.robinhood.request_get(url,'regular')    # For when you want
+>>> robin_stocks.robinhood.request_get(url=url, dataType='regular')    # For when you want
 >>>                                            # the whole dictionary
 >>>                                            # to view 'next' or
 >>>                                            # 'previous' values.
 >>>
->>> robin_stocks.robinhood.request_get(url,'results')    # For when results contains a
+>>> robin_stocks.robinhood.request_get(url=url, dataType='results')    # For when results contains a
 >>>                                            # list or single dictionary.
 >>>
->>> robin_stocks.robinhood.request_get(url,'pagination') # For when results contains a
+>>> robin_stocks.robinhood.request_get(url=url, dataType='pagination') # For when results contains a
 >>>                                            # list, but you also want to
 >>>                                            # append any information in
 >>>                                            # 'next' to the list.
 >>>
->>> robin_stocks.robinhood.request_get(url,'indexzero')  # For when results is a list
+>>> robin_stocks.robinhood.request_get(url=url, dataType='indexzero')  # For when results is a list
 >>>                                            # of only one entry.
 
 Also keep in mind that the results from the Robinhood API have been decoded using ``.json()``.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -54,7 +54,7 @@ Now you should be able to login with the following code,
 >>> import pyotp
 >>> import robin_stocks.robinhood as r
 >>> totp  = pyotp.TOTP("My2factorAppHere").now()
->>> login = r.login('joshsmith@email.com','password', mfa_code=totp)
+>>> login = r.login(username='joshsmith@email.com', password='password', mfa_code=totp)
 
 Not all of the functions contained in the module need the user to be authenticated. A lot of the functions
 contained in the modules 'stocks' and 'options' do not require authentication, but it's still good practice
@@ -78,13 +78,13 @@ Trading stocks, options, and crypto-currencies is one of the most powerful featu
 Robinhood supports it. Here is a list of possible trades you can make
 
 >>> #Buy 10 shares of Apple at market price
->>> robin_stocks.order_buy_market('AAPL',10)
+>>> robin_stocks.order_buy_market(symbol='AAPL',quantity=10)
 >>> #Sell half a Bitcoin is price reaches 10,000
->>> robin_stocks.order_sell_crypto_limit('BTC',0.5,10000)
+>>> robin_stocks.order_sell_crypto_limit(symbol='BTC',quantity=0.5,limitPrice=10000)
 >>> #Buy $500 worth of Bitcoin
->>> robin_stocks.order_buy_crypto_by_price('BTC',500)
+>>> robin_stocks.order_buy_crypto_by_price(symbol='BTC',amountInDollars=500)
 >>> #Buy 5 $150 May 1st, 2020 SPY puts if the price per contract is $1.00. Good until cancelled.
->>> robin_stocks.order_buy_option_limit('open','debit',1.00,'SPY',5,'2020-05-01',150,'put','gtc')
+>>> robin_stocks.order_buy_option_limit(positionEffect='open', creditOrDebit='debit', price=1.00, symbol='SPY', quantity=5,expirationDate='2020-05-01', strike=150, optionType='put',timeInForce='gtc')
 
 Now let's try a slightly more complex example. Let's say you wanted to sell half your Tesla stock if it fell to 200.00.
 To do this you would type
@@ -94,10 +94,10 @@ To do this you would type
 >>> ## does not provide that information in the stock orders.
 >>> ## This process is very slow since it is making a GET request for each order.
 >>> for item in positions_data:
->>>     item['symbol'] = robin_stocks.get_symbol_by_url(item['instrument'])
+>>>     item['symbol'] = robin_stocks.get_symbol_by_url(url=item['instrument'])
 >>> TSLAData = [item for item in positions_data if item['symbol'] == 'TSLA']
 >>> sellQuantity = float(TSLAData['quantity'])//2.0
->>> robin_stocks.order_sell_limit('TSLA',sellQuantity,200.00)
+>>> robin_stocks.order_sell_limit(symbol='TSLA', quantity=sellQuantity,limitPrice=200.00)
 
 Also be aware that all the order functions default to 'gtc' or 'good until cancelled'. To change this, pass one of the following in as
 the last parameter in the function: 'gfd'(good for the day), 'ioc'(immediate or cancel), or 'opg'(execute at opening).
@@ -126,10 +126,10 @@ If you want to cancel all your limit sells, you would type
 >>> ## Note: Again we are adding symbol to our list of orders because Robinhood
 >>> ## does not include this with the order information.
 >>> for item in positions_data:
->>>    item['symbol'] = robin_stocks.get_crypto_quote_from_id(item['currency_pair_id'], 'symbol')
+>>>    item['symbol'] = robin_stocks.get_crypto_quote_from_id(id=item['currency_pair_id'], info='symbol')
 >>> btcOrders = [item for item in positions_data if item['symbol'] == 'BTCUSD' and item['side'] == 'sell']
 >>> for item in btcOrders:
->>>    robin_stocks.cancel_crypto_order(item['id'])
+>>>    robin_stocks.cancel_crypto_order(orderId=item['id'])
 
 Saving to CSV File
 ------------------
@@ -139,8 +139,8 @@ can be either absolute or relative. To save the file in the current directory, s
 file extension. If it is missing it will be added, and any other file extension will be automatically changed. Below are example calls.
 
 >>> # let's say that I am running code from C:/Users/josh/documents/
->>> r.export_completed_stock_orders(".") # saves at C:/Users/josh/documents/stock_orders_Jun-28-2020.csv
->>> r.export_completed_option_orders("../", "toplevel") # save at C:/Users/josh/toplevel.csv
+>>> r.export_completed_stock_orders(dir_path=".") # saves at C:/Users/josh/documents/stock_orders_Jun-28-2020.csv
+>>> r.export_completed_option_orders(dir_path="../", file_name="toplevel") # save at C:/Users/josh/toplevel.csv
 
 Using Option Spreads
 --------------------

--- a/examples/gemini examples/basic_private_api_usage.py
+++ b/examples/gemini examples/basic_private_api_usage.py
@@ -9,8 +9,8 @@ from dotenv import load_dotenv
 ##
 ticker = "btcusd"
 ##
-g.login(os.environ['gemini_account_key'], os.environ['gemini_account_secret'])
-my_trades, error = g.get_trades_for_crypto(ticker, jsonify=True)
+g.login(api_key=os.environ['gemini_account_key'], secret_key=os.environ['gemini_account_secret'])
+my_trades, error = g.get_trades_for_crypto(ticker=ticker, jsonify=True)
 if error:
     print("oh my an error")
 else:

--- a/examples/gemini examples/basic_public_api_usage.py
+++ b/examples/gemini examples/basic_public_api_usage.py
@@ -2,7 +2,7 @@
 '''
 import robin_stocks.gemini as g
 
-response, error = g.get_pubticker("cheese")
+response, error = g.get_pubticker(ticker="cheese")
 
 if error:
     print("there was an error!")
@@ -11,7 +11,7 @@ if error:
 
 print("let's try that again")
 
-response, error = g.get_pubticker("btcusd")
+response, error = g.get_pubticker(ticker="btcusd")
 
 if not error:
     print("it worked this time!")
@@ -20,16 +20,16 @@ if not error:
 
 print("i don't care about raw response anymore, let's get json by default! This will apply to all functions from now on.")
 
-g.set_default_json_flag(True)
+g.set_default_json_flag(parse_json=True)
 
-response, error = g.get_pubticker("btcusd")
+response, error = g.get_pubticker(ticker="btcusd")
 
 print("reponse is the json format now!")
 print(response)
 
 print("you can also set whether you want the json format directly for each function by passing in jsonify")
 
-response, error = g.get_pubticker("btcusd", jsonify=False)
+response, error = g.get_pubticker(ticker="btcusd", jsonify=False)
 
 print("this function is back to raw response")
 print(response)

--- a/examples/robinhood examples/auto_retry_order.py
+++ b/examples/robinhood examples/auto_retry_order.py
@@ -22,15 +22,15 @@ sleep_time = 1 # in seconds
 load_dotenv()
 # Login using two-factor code
 totp = pyotp.TOTP(os.environ['robin_mfa']).now()
-login = r.login(os.environ['robin_username'], os.environ['robin_password'], store_session=True, mfa_code=totp)
+login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], store_session=True, mfa_code=totp)
 # Here it is important to set jsonify=False so that you can check
 # status code of your order request. 200 is ok, 400 is bad request,
 # and 404 is unknown url.
-order = r.order_buy_market(stock, quantity, jsonify=False)
+order = r.order_buy_market(symbol=stock, quantity=quantity, jsonify=False)
 # Feel free to use more advanced orders
 attempts = 0
 while order.status_code != 200 and attempts < max_attempts:
-    order = r.order_buy_market(stock, quantity, jsonify=False)
+    order = r.order_buy_market(symbol=stock, quantity=quantity, jsonify=False)
     attempts += 1
     sleep(sleep_time)
 

--- a/examples/robinhood examples/check_performance.py
+++ b/examples/robinhood examples/check_performance.py
@@ -9,22 +9,22 @@ username = ''
 password = ''
 #!!!
 
-login = r.login(username, password)
+login = r.login(username=username, password=password)
 
 # Query your positions
 positions = r.get_open_stock_positions()
 
 # Get Ticker symbols
-tickers = [r.get_symbol_by_url(item["instrument"]) for item in positions]
+tickers = [r.get_symbol_by_url(url=item["instrument"]) for item in positions]
 
 # Get your quantities
 quantities = [float(item["quantity"]) for item in positions]
 
 # Query previous close price for each stock ticker
-prevClose = r.get_quotes(tickers, "previous_close")
+prevClose = r.get_quotes(inputSymbols=tickers, info="previous_close")
 
 # Query last trading price for each stock ticker
-lastPrice = r.get_quotes(tickers, "last_trade_price")
+lastPrice = r.get_quotes(inputSymbols=tickers, info="last_trade_price")
 
 # Calculate the profit per share
 profitPerShare = [float(lastPrice[i]) - float(prevClose[i]) for i in range(len(tickers))]

--- a/examples/robinhood examples/close_option_position.py
+++ b/examples/robinhood examples/close_option_position.py
@@ -9,18 +9,18 @@ username = ''
 password = ''
 #!!!
 
-login = r.login(username, password)
+login = r.login(username=username, password=password)
 
 # Let's say you bought five 4/20/20 calls of spy at 300 for 1.00 per contract.
 # You would like to sell the calls for 2.00 per contract so you double your money (minus premium).
 # Also, you want the order to last until you cancel it. You would sell to close like this.
 
-r.order_sell_option_limit("close", "credit", "2.0", "SPY", 5, "2020-04-20", 300, "call", "gtc")
+r.order_sell_option_limit(positionEffect="close", creditOrDebit="credit", price="2.0", symbol="SPY", quantity=5, expirationDate="2020-04-20", strike=300, optionType="call", timeInForce="gtc")
 
 # Let's say you sold one 4/20/20 put of spy at 200 for 5.00 per contract.
 # You would like to buy the puts for 2.50 per contract so you double your money (plus premium).
 # Also, you only want the order to last the day. You would buy to close like this.
 
-r.order_buy_option_limit("close", "debit", "2.5", "SPY", 1, "2020-04-20", 200, "put", "gfd")
+r.order_buy_option_limit(positionEffect="close", creditOrDebit="debit", price="2.5", symbol="SPY", quantity=1, expirationDate="2020-04-20", strike=200, optionType="put", timeInForce="gfd")
 
 # if you don't already own these contracts then robinhood should return an error and not let the order go through.

--- a/examples/robinhood examples/deposit_funds_to_robinhood_account.py
+++ b/examples/robinhood examples/deposit_funds_to_robinhood_account.py
@@ -17,11 +17,11 @@ amount_to_deposit = "REPLACE-ME"
 load_dotenv()
 # Login using two-factor code
 totp = pyotp.TOTP(os.environ['robin_mfa']).now()
-login = r.login(os.environ['robin_username'],
-                os.environ['robin_password'], store_session=True, mfa_code=totp)
+login = r.login(username=os.environ['robin_username'],
+                password=os.environ['robin_password'], store_session=True, mfa_code=totp)
 # Get the bank account information
 bank_accounts = r.get_linked_bank_accounts()
-account_names = r.filter_data(bank_accounts, 'bank_account_nickname')
+account_names = r.filter_data(data=bank_accounts, info='bank_account_nickname')
 # set up default variable values for business logic
 count = 1
 valid_choice = False
@@ -63,5 +63,5 @@ elif bank_choice == count:
 else:
     ach_relationship = bank_accounts[bank_choice - 1]['url']
     deposit = r.deposit_funds_to_robinhood_account(
-        ach_relationship, amount_to_deposit)
+        ach_relationship=ach_relationship, amount=amount_to_deposit)
     print(deposit)

--- a/examples/robinhood examples/get_accurate_gains.py
+++ b/examples/robinhood examples/get_accurate_gains.py
@@ -15,7 +15,7 @@ username = ''
 password = ''
 #!!!
 
-login = r.login(username,password)
+login = r.login(username=username,password=password)
 
 profileData = r.load_portfolio_profile()
 allTransactions = r.get_bank_transfers()

--- a/examples/robinhood examples/get_data_from_tags.py
+++ b/examples/robinhood examples/get_data_from_tags.py
@@ -14,29 +14,29 @@ two-factor loggin in works.
 load_dotenv()
 # Login using two-factor code.
 totp = pyotp.TOTP(os.environ['robin_mfa']).now()
-login = r.login(os.environ['robin_username'],
-                os.environ['robin_password'], store_session=True, mfa_code=totp)
+login = r.login(username=os.environ['robin_username'],
+                password=os.environ['robin_password'], store_session=True, mfa_code=totp)
 # Get 500 technology stocks data.
 stocks = r.request_get(
-    "https://api.robinhood.com/midlands/tags/tag/technology/")
+    url="https://api.robinhood.com/midlands/tags/tag/technology/")
 print(
     f"\nthere are a total of {stocks['membership_count']} technology stocks, currently viewing {len(stocks['instruments'])}")
 # Turn the raw dictionary into a list of strings using the filter_data function.
 # This list of strings are the urls for the quote data of each stock.
 # The quote data can be retrieved using get_instrument_by_url() or
 # by using request_get to query the url directly.
-data = r.filter_data(stocks, 'instruments')
+data = r.filter_data(data=stocks, info='instruments')
 first = data[0]
-first_data = r.request_get(first)
+first_data = r.request_get(url=first)
 print("\n======the quote data for the first entry is=====\n")
 print(first_data)
 print("\ngetting the rest of the quote data now. This may take a minute....")
-full_quote_data = [r.request_get(x) for x in data]
+full_quote_data = [r.request_get(url=x) for x in data]
 print("Now I am getting the filter data...")
 #I can also filter the data
 margin_quote_data = []
 for entry in data:
-    quote_data = r.request_get(entry)
+    quote_data = r.request_get(url=entry)
     if float(quote_data['margin_initial_ratio']) > 0.5:
         margin_quote_data.append(quote_data)
 print(f"There are {len(margin_quote_data)} entries that fit the criteria.")

--- a/examples/robinhood examples/get_option_historicals.py
+++ b/examples/robinhood examples/get_option_historicals.py
@@ -18,11 +18,11 @@ username = ''
 password = ''
 #!!!
 
-login = r.login(username,password)
+login = r.login(username=username, password=password)
 
 #!!! fill out the specific option information
 symbol = 'AAPL'
-symbol_name = r.get_name_by_symbol(symbol)
+symbol_name = r.get_name_by_symbol(symbol=symbol)
 expirationDate = '2020-07-02' # format is YYYY-MM-DD.
 strike = 300
 optionType = 'call' # available options are 'call' or 'put' or None.
@@ -32,7 +32,7 @@ bounds = 'regular' # available options are 'regular', 'trading', and 'extended'.
 info = None
 #!!!
 
-historicalData = r.get_option_historicals(symbol, expirationDate, strike, optionType, interval, span, bounds, info)
+historicalData = r.get_option_historicals(symbol=symbol, expirationDate=expirationDate, strikePrice=strike, optionType=optionType, interval=interval, span=span, bounds=bounds, info=info)
 
 dates = []
 closingPrices = []

--- a/examples/robinhood examples/place_vertical_spread.py
+++ b/examples/robinhood examples/place_vertical_spread.py
@@ -8,7 +8,7 @@ username = ''
 password = ''
 #!!!
 
-login = r.login(username,password)
+login = r.login(username=username, password=password)
 
 #!!! WARNING - Some option spreads have UNLIMITED risk.
 #!!! Note - Make sure to check the prices of option legs before placing a spread order. Some vertical spreads carry more risk.
@@ -31,5 +31,5 @@ leg2 = {"expirationDate":"2019-12-20",
 spread = [leg1,leg2]
 #!!!
 
-order = r.order_option_spread("debit", 3.10, "PLUG", 1, spread)
+order = r.order_option_spread(direction="debit", price=3.10, symbol="PLUG", quantity=1, spread=spread)
 print(order)

--- a/examples/robinhood examples/two_factor_log_in.py
+++ b/examples/robinhood examples/two_factor_log_in.py
@@ -23,8 +23,8 @@ load_dotenv()
 totp = pyotp.TOTP(os.environ['robin_mfa']).now()
 print("Current OTP:", totp)
 # Here I am setting store_session=False so no pickle file is used.
-login = r.login(os.environ['robin_username'],
-                os.environ['robin_password'], store_session=False, mfa_code=totp)
+login = r.login(username=os.environ['robin_username'],
+                password=os.environ['robin_password'], store_session=False, mfa_code=totp)
 # In the login dictionary, you will see that 'detail' is 
 # 'logged in with brand new authentication code.' to show that I am not using a pickle file.
 print(login)

--- a/examples/robinhood examples/withdrawl_funds_to_bank_account.py
+++ b/examples/robinhood examples/withdrawl_funds_to_bank_account.py
@@ -17,11 +17,11 @@ amount_to_withdrawl = "REPLACE-ME"
 load_dotenv()
 # Login using two-factor code
 totp = pyotp.TOTP(os.environ['robin_mfa']).now()
-login = r.login(os.environ['robin_username'],
-                os.environ['robin_password'], store_session=True, mfa_code=totp)
+login = r.login(username=os.environ['robin_username'],
+                password=os.environ['robin_password'], store_session=True, mfa_code=totp)
 # Get the bank account information
 bank_accounts = r.get_linked_bank_accounts()
-account_names = r.filter_data(bank_accounts, 'bank_account_nickname')
+account_names = r.filter_data(data=bank_accounts, info='bank_account_nickname')
 # set up default variable values for business logic
 count = 1
 valid_choice = False
@@ -62,5 +62,5 @@ elif bank_choice == count:
     print("you chose to cancel. Exiting...")
 else:
     ach_relationship = bank_accounts[bank_choice - 1]['url']
-    withdrawl = r.withdrawl_funds_to_bank_account(ach_relationship, amount_to_withdrawl)
+    withdrawl = r.withdrawl_funds_to_bank_account(ach_relationship=ach_relationship, amount=amount_to_withdrawl)
     print(withdrawl)

--- a/examples/robinhood examples/write_options_to_file.py
+++ b/examples/robinhood examples/write_options_to_file.py
@@ -13,7 +13,7 @@ username = ''
 password = ''
 #!!!
 
-login = r.login(username,password)
+login = r.login(username=username, password=password)
 
 #!!! fill out the specific option information
 strike = 300
@@ -42,8 +42,8 @@ while t.time() < endTime:
     fileStream.write(time)
     print(time)
     #Get the data
-    instrument_data = r.get_option_instrument_data(stock,date,strike,optionType)
-    market_data = r.get_option_market_data(stock,date,strike,optionType)
+    instrument_data = r.get_option_instrument_data(symbol=stock,expirationDate=date,strikePrice=strike,optionType=optionType)
+    market_data = r.get_option_market_data(inputSymbols=stock, expirationDate=date,strikePrice=strike,optionType=optionType)
 
     fileStream.write("\n")
     fileStream.write("{} Instrument Data {}".format("="*30,"="*30))

--- a/examples/tda examples/basic_authentication.py
+++ b/examples/tda examples/basic_authentication.py
@@ -18,11 +18,11 @@ print("here is a key you can use for encryption: ", keep_this_key_somewhere_safe
 
 #!!! Only call login_first_time once! Delete this code after running the first time!
 t.login_first_time(
-    keep_this_key_somewhere_safe,
-    "client_id_goes_here",
-    "authorization_token_goes_here",
-    "refresh_token_goes_here")
+    encryption_passcode=keep_this_key_somewhere_safe,
+    client_id="client_id_goes_here",
+    authorization_token="authorization_token_goes_here",
+    refresh_token="refresh_token_goes_here")
 #!!!
 
 # Call login as much as you want.
-t.login(os.environ["tda_encryption_passcode"])
+t.login(encryption_passcode=os.environ["tda_encryption_passcode"])

--- a/examples/tda examples/place_order_and_cancel.py
+++ b/examples/tda examples/place_order_and_cancel.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # login
-tda.login(os.environ["tda_encryption_passcode"])
+tda.login(encryption_passcode=os.environ["tda_encryption_passcode"])
 # format the order payload
 order = {
     "orderType": "MARKET",
@@ -26,9 +26,9 @@ order = {
         }
     ]
 }
-data, err = tda.place_order(os.environ["tda_order_account"], order, True)
-order_id = tda.get_order_number(data)
+data, err = tda.place_order(account_id=os.environ["tda_order_account"], order_payload=order, jsonify=True)
+order_id = tda.get_order_number(data=data)
 print("the order has been placed and the order id is ", order_id)
-cancel, err = tda.cancel_order(os.environ["tda_order_account"], order_id, False)
+cancel, err = tda.cancel_order(account_id=os.environ["tda_order_account"], order_id=order_id, jsonify=False)
 print("the order has been cancelled")
 print(cancel.headers)

--- a/gemini.rst
+++ b/gemini.rst
@@ -38,7 +38,7 @@ Logging in
 Loggin in is very simple. Just type
 
 >>> import robin_stocks.gemini as g
->>> g.login("account-apigoeshere", "secret-api-goes-here")
+>>> g.login(api_key="account-apigoeshere", secret_key="secret-api-goes-here")
 
 Be aware that only functions that are decorated with @login_required need you to be logged in.
 The rest can be called without you having to login.

--- a/robin_stocks/gemini/account.py
+++ b/robin_stocks/gemini/account.py
@@ -32,10 +32,10 @@ def get_account_detail(jsonify=None):
     """
     url = URLS.account_detail()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -60,10 +60,10 @@ def check_available_balances(jsonify=None):
     """
     url = URLS.available_balances()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -90,10 +90,10 @@ def check_notional_balances(jsonify=None):
     """
     url = URLS.notional_balances()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -130,19 +130,19 @@ def check_transfers(timestamp=None, limit_transfers=10, show_completed_deposit_a
     """
     url = URLS.transfers()
     payload = {
-        "request": URLS.get_endpoint(url),
+        "request": URLS.get_endpoint(url=url),
         "show_completed_deposit_advances": show_completed_deposit_advances
     }
     if timestamp:
         payload["timestamp"] = timestamp
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
 @login_required
 @format_inputs
-def get_deposit_addresses(network, timestamp=None,  jsonify=None):
+def get_deposit_addresses(network, timestamp=None, jsonify=None):
     """ Gets a list of all deposit addresses.
 
     :param network: network can be bitcoin, ethereum, bitcoincash, litecoin, zcash, filecoin.
@@ -161,14 +161,14 @@ def get_deposit_addresses(network, timestamp=None,  jsonify=None):
                       * label - Optional. if you provided a label when creating the address, it will be echoed back here.
 
     """
-    url = URLS.deposit_addresses(network)
+    url = URLS.deposit_addresses(network=network)
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
     if timestamp:
         payload["timestamp"] = timestamp
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -195,12 +195,12 @@ def get_approved_addresses(network, jsonify=None):
                         -- address - The address on the approved address list.
 
     """
-    url = URLS.approved_addresses(network)
+    url = URLS.approved_addresses(network=network)
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -233,12 +233,12 @@ def withdraw_crypto_funds(currency_code, address, amount, jsonify=None):
                       * message - A human-readable English string describing the withdrawal. Only shown for BTC, ZEC, LTC and BCH withdrawals.
 
     """
-    url = URLS.withdrawl_crypto(currency_code)
+    url = URLS.withdrawl_crypto(currency_code=currency_code)
     payload = {
-        "request": URLS.get_endpoint(url),
+        "request": URLS.get_endpoint(url=url),
         "address": address,
         "amount": amount
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err

--- a/robin_stocks/gemini/authentication.py
+++ b/robin_stocks/gemini/authentication.py
@@ -17,17 +17,17 @@ from robin_stocks.gemini.urls import URLS
 def login(api_key, secret_key):
     """ Set the authorization token so the API can be used.
     """
-    update_session("X-GEMINI-APIKEY", api_key)
-    set_secret_key(secret_key.encode())
-    set_login_state(True)
+    update_session(key="X-GEMINI-APIKEY", value=api_key)
+    set_secret_key(data=secret_key.encode())
+    set_login_state(logged_in=True)
 
 
 def logout():
     """ Removes the API and Secret key from session and global variables.
     """
-    update_session("X-GEMINI-APIKEY", "")
-    set_secret_key("".encode())
-    set_login_state(False)
+    update_session(key="X-GEMINI-APIKEY", value="")
+    set_secret_key(data="".encode())
+    set_login_state(logged_in=False)
 
 
 def generate_signature(payload):
@@ -43,8 +43,8 @@ def generate_signature(payload):
     encoded_payload = dumps(payload).encode()
     b64 = b64encode(encoded_payload)
     signature = new(gemini_api_secret, b64, sha384).hexdigest()
-    update_session("X-GEMINI-PAYLOAD", b64)
-    update_session("X-GEMINI-SIGNATURE", signature)
+    update_session(key="X-GEMINI-PAYLOAD", value=b64)
+    update_session(key="X-GEMINI-SIGNATURE", value=signature)
     increment_nonce()
 
 
@@ -84,8 +84,8 @@ def heartbeat(jsonify=None):
     """
     url = URLS.heartbeat()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err

--- a/robin_stocks/gemini/crypto.py
+++ b/robin_stocks/gemini/crypto.py
@@ -23,8 +23,8 @@ def get_pubticker(ticker, jsonify=None):
                       * volume - Information about the 24 hour volume on the exchange
 
     """
-    url = URLS.pubticker(ticker)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.pubticker(ticker=ticker)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -52,8 +52,8 @@ def get_ticker(ticker, jsonify=None):
 
 
     """
-    url = URLS.ticker(ticker)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.ticker(ticker=ticker)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -70,7 +70,7 @@ def get_symbols(jsonify=None):
 
     """
     url = URLS.symbols()
-    data, error = request_get(url, None, jsonify)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -97,8 +97,8 @@ def get_symbol_details(ticker, jsonify=None):
 
 
     """
-    url = URLS.symbol_details(ticker)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.symbol_details(ticker=ticker)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -132,10 +132,10 @@ def get_notional_volume(jsonify=None):
     """
     url = URLS.notional_volume()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -173,10 +173,10 @@ def get_trade_volume(jsonify=None):
     """
     url = URLS.trade_volume()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -190,7 +190,7 @@ def get_price(ticker, side):
     :returns: Returns the bid or ask price as a string.
 
     """
-    data, _ = get_pubticker(ticker, jsonify=True)
+    data, _ = get_pubticker(ticker=ticker, jsonify=True)
     if side == "buy":
         return data["ask"]
     else:

--- a/robin_stocks/gemini/orders.py
+++ b/robin_stocks/gemini/orders.py
@@ -41,15 +41,15 @@ def get_trades_for_crypto(ticker, limit_trades=50, timestamp=None, jsonify=None)
     """
     url = URLS.mytrades()
     payload = {
-        "request": URLS.get_endpoint(url),
+        "request": URLS.get_endpoint(url=url),
         "symbol": ticker,
         "limit_trades": limit_trades
     }
     if timestamp:
         payload["timestamp"] = timestamp
 
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -71,10 +71,10 @@ def cancel_all_session_orders(jsonify=None):
     """
     url = URLS.cancel_session_orders()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -96,10 +96,10 @@ def cancel_all_active_orders(jsonify=None):
     """
     url = URLS.cancel_active_orders()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -140,11 +140,11 @@ def cancel_order(order_id, jsonify=None):
     """
     url = URLS.cancel_order()
     payload = {
-        "request": URLS.get_endpoint(url),
+        "request": URLS.get_endpoint(url=url),
         "order_id": order_id
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -185,11 +185,11 @@ def order_status(order_id, jsonify=None):
     """
     url = URLS.order_status()
     payload = {
-        "request": URLS.get_endpoint(url),
+        "request": URLS.get_endpoint(url=url),
         "order_id": order_id
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -227,10 +227,10 @@ def active_orders(jsonify=None):
     """
     url = URLS.active_orders()
     payload = {
-        "request": URLS.get_endpoint(url)
+        "request": URLS.get_endpoint(url=url)
     }
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err
 
 
@@ -274,11 +274,11 @@ def order_market(ticker, quantity, side, jsonify=None):
                       * is_hidden - Will always return false unless the order was placed with the indication-of-interest execution option.
     """
     if side == "buy":
-        far_limit_price = float(get_price(ticker, side)) * 10
+        far_limit_price = float(get_price(ticker=ticker, side=side)) * 10
     else:
-        far_limit_price = float(get_price(ticker, side)) / 10
+        far_limit_price = float(get_price(ticker=ticker, side=side)) / 10
     price = str(round(far_limit_price, 2))
-    return order(ticker, quantity, side, price, None, None, ["immediate-or-cancel"], jsonify=jsonify)
+    return order(None, None, ["immediate-or-cancel"], ticker=ticker, quantity=quantity, side=side, price=price, jsonify=jsonify)
 
 
 @login_required
@@ -330,7 +330,7 @@ def order(ticker, quantity, side, price=None, stop_limit_price=None, min_amount=
     url = URLS.order_new()
     payload = {
         "client_order_id": generate_order_id(),
-        "request": URLS.get_endpoint(url),
+        "request": URLS.get_endpoint(url=url),
         "symbol": ticker,
         "amount": str(quantity),
         "side": side
@@ -339,7 +339,7 @@ def order(ticker, quantity, side, price=None, stop_limit_price=None, min_amount=
     if price:
         payload["price"] = price
     else:
-        payload["price"] = get_price(ticker, side)
+        payload["price"] = get_price(ticker=ticker, side=side)
     #
     if stop_limit_price:
         payload["type"] = "exchange stop limit"
@@ -353,6 +353,6 @@ def order(ticker, quantity, side, price=None, stop_limit_price=None, min_amount=
     if options:
         payload["options"] = options
 
-    generate_signature(payload)
-    data, err = request_post(url, payload, jsonify)
+    generate_signature(payload=payload)
+    data, err = request_post(url=url, payload=payload, parse_json=jsonify)
     return data, err

--- a/robin_stocks/gemini/urls.py
+++ b/robin_stocks/gemini/urls.py
@@ -50,87 +50,87 @@ class URLS:
     # account.py
     @classmethod
     def account_detail(cls):
-        return cls.get_base_url(Version.v1) + "account"
+        return cls.get_base_url(version=Version.v1) + "account"
 
     @classmethod
     def available_balances(cls):
-        return cls.get_base_url(Version.v1) + "balances"
+        return cls.get_base_url(version=Version.v1) + "balances"
 
     @classmethod
     def notional_balances(cls):
-        return cls.get_base_url(Version.v1) + "notionalbalances/usd"
+        return cls.get_base_url(version=Version.v1) + "notionalbalances/usd"
 
     @classmethod
     def transfers(cls):
-        return cls.get_base_url(Version.v1) + "transfers"
+        return cls.get_base_url(version=Version.v1) + "transfers"
 
     @classmethod
     def deposit_addresses(cls, network):
-        return cls.get_base_url(Version.v1) + "addresses/{0}".format(network)
+        return cls.get_base_url(version=Version.v1) + "addresses/{0}".format(network)
 
     @classmethod
     def approved_addresses(cls, network):
-        return cls.get_base_url(Version.v1) + "approvedAddresses/account/{0}".format(network)
+        return cls.get_base_url(version=Version.v1) + "approvedAddresses/account/{0}".format(network)
 
     @classmethod
     def withdrawl_crypto(cls, currency_code):
-        return cls.get_base_url(Version.v1) + "withdraw/{0}".format(currency_code)
+        return cls.get_base_url(version=Version.v1) + "withdraw/{0}".format(currency_code)
 
     # authentication.py
     @classmethod
     def heartbeat(cls):
-        return cls.get_base_url(Version.v1) + "heartbeat"
+        return cls.get_base_url(version=Version.v1) + "heartbeat"
 
     # crypto.py
     @classmethod
     def pubticker(cls, ticker):
-        return cls.get_base_url(Version.v1) + "pubticker/{0}".format(ticker)
+        return cls.get_base_url(version=Version.v1) + "pubticker/{0}".format(ticker)
 
     @classmethod
     def ticker(cls, ticker):
-        return cls.get_base_url(Version.v2) + "ticker/{0}".format(ticker)
+        return cls.get_base_url(version=Version.v2) + "ticker/{0}".format(ticker)
 
     @classmethod
     def symbols(cls):
-        return cls.get_base_url(Version.v1) + "symbols"
+        return cls.get_base_url(version=Version.v1) + "symbols"
 
     @classmethod
     def symbol_details(cls, ticker):
-        return cls.get_base_url(Version.v1) + "symbols/details/{0}".format(ticker)
+        return cls.get_base_url(version=Version.v1) + "symbols/details/{0}".format(ticker)
 
     @classmethod
     def notional_volume(cls):
-        return cls.get_base_url(Version.v1) + "notionalvolume"
+        return cls.get_base_url(version=Version.v1) + "notionalvolume"
 
     @classmethod
     def trade_volume(cls):
-        return cls.get_base_url(Version.v1) + "tradevolume"
+        return cls.get_base_url(version=Version.v1) + "tradevolume"
 
     # orders.py
     @classmethod
     def mytrades(cls):
-        return cls.get_base_url(Version.v1) + "mytrades"
+        return cls.get_base_url(version=Version.v1) + "mytrades"
 
     @classmethod
     def cancel_session_orders(cls):
-        return cls.get_base_url(Version.v1) + "order/cancel/session"
+        return cls.get_base_url(version=Version.v1) + "order/cancel/session"
 
     @classmethod
     def cancel_order(cls):
-        return cls.get_base_url(Version.v1) + "order/cancel"
+        return cls.get_base_url(version=Version.v1) + "order/cancel"
 
     @classmethod
     def order_status(cls):
-        return cls.get_base_url(Version.v1) + "order/status"
+        return cls.get_base_url(version=Version.v1) + "order/status"
 
     @classmethod
     def active_orders(cls):
-        return cls.get_base_url(Version.v1) + "orders"
+        return cls.get_base_url(version=Version.v1) + "orders"
 
     @classmethod
     def cancel_active_orders(cls):
-        return cls.get_base_url(Version.v1) + "order/cancel/all"
+        return cls.get_base_url(version=Version.v1) + "order/cancel/all"
 
     @classmethod
     def order_new(cls):
-        return cls.get_base_url(Version.v1) + "order/new"
+        return cls.get_base_url(version=Version.v1) + "order/new"

--- a/robin_stocks/robinhood/account.py
+++ b/robin_stocks/robinhood/account.py
@@ -46,8 +46,8 @@ def load_phoenix_account(info=None):
 
     """
     url = phoenix_url()
-    data = request_get(url, 'regular')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='regular')
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_historical_portfolio(interval=None, span='week', bounds='regular',info=None):
@@ -73,15 +73,15 @@ def get_historical_portfolio(interval=None, span='week', bounds='regular',info=N
         return([None])
 
     account = load_account_profile(info='account_number')
-    url = portfolis_historicals_url(account)
+    url = portfolis_historicals_url(account_number=account)
     payload = {
         'interval': interval,
         'span': span,
         'bounds': bounds
     }
-    data = request_get(url, 'regular', payload)
+    data = request_get(url=url, dataType='regular', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_all_positions(info=None):
@@ -111,9 +111,9 @@ def get_all_positions(info=None):
 
     """
     url = positions_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -147,9 +147,9 @@ def get_open_stock_positions(account_number=None, info=None):
     """
     url = positions_url(account_number=account_number)
     payload = {'nonzero': 'true'}
-    data = request_get(url, 'pagination', payload)
+    data = request_get(url=url, dataType='pagination', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -178,9 +178,9 @@ def get_dividends(info=None):
 
     """
     url = dividends_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -191,7 +191,7 @@ def get_total_dividends():
 
     """
     url = dividends_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     dividend_total = 0
     for item in data:
@@ -240,9 +240,9 @@ def get_notifications(info=None):
 
     """
     url = notifications_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -252,8 +252,8 @@ def get_latest_notification():
     :returns: Returns a dictionary of key/value pairs. But there is only one key, 'last_viewed_at'
 
     """
-    url = notifications_url(True)
-    data = request_get(url)
+    url = notifications_url(tracker=True)
+    data = request_get(url=url)
     return(data)
 
 
@@ -268,8 +268,8 @@ def get_wire_transfers(info=None):
 
     """
     url = wiretransfers_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -288,10 +288,10 @@ def get_margin_calls(symbol=None):
         except AttributeError as message:
             print(message, file=get_output())
             return None
-        payload = {'equity_instrument_id', id_for_stock(symbol)}
-        data = request_get(url, 'results', payload)
+        payload = {'equity_instrument_id', id_for_stock(symbol=symbol)}
+        data = request_get(url=url, dataType='results', payload=payload)
     else:
-        data = request_get(url, 'results')
+        data = request_get(url=url, dataType='results')
 
     return(data)
 
@@ -316,8 +316,8 @@ def withdrawl_funds_to_bank_account(ach_relationship, amount, info=None):
         "ach_relationship": ach_relationship,
         "ref_id": str(uuid4())
     }
-    data = request_post(url, payload)
-    return(filter_data(data, info))
+    data = request_post(url=url, payload=payload)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -340,8 +340,8 @@ def deposit_funds_to_robinhood_account(ach_relationship, amount, info=None):
         "ach_relationship": ach_relationship,
         "ref_id": str(uuid4())
     }
-    data = request_post(url, payload)
-    return(filter_data(data, info))
+    data = request_post(url=url, payload=payload)
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_linked_bank_accounts(info=None):
@@ -353,8 +353,8 @@ def get_linked_bank_accounts(info=None):
 
     """
     url = linked_url()
-    data = request_get(url, 'results')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='results')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -369,9 +369,9 @@ def get_bank_account_info(id, info=None):
     the value of the key that matches info is extracted.
 
     """
-    url = linked_url(id)
-    data = request_get(url)
-    return(filter_data(data, info))
+    url = linked_url(id=id)
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -383,8 +383,8 @@ def unlink_bank_account(id):
     :returns: Information returned from post request.
 
     """
-    url = linked_url(id, True)
-    data = request_post(url)
+    url = linked_url(id=id, unlink=True)
+    data = request_post(url=url)
     return(data)
 
 
@@ -402,9 +402,9 @@ def get_bank_transfers(direction=None, info=None):
     a list of strings is returned where the strings are the value of the key that matches info.
 
     """
-    url = banktransfers_url(direction)
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    url = banktransfers_url(direction=direction)
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_card_transactions(cardType=None, info=None):
@@ -423,8 +423,8 @@ def get_card_transactions(cardType=None, info=None):
         payload = { 'type': type }
 
     url = cardtransactions_url()
-    data = request_get(url, 'pagination', payload)
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination', payload=payload)
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_stock_loan_payments(info=None):
@@ -437,8 +437,8 @@ def get_stock_loan_payments(info=None):
 
     """
     url = stockloan_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -452,8 +452,8 @@ def get_margin_interest(info=None):
 
     """
     url = margininterest_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -467,8 +467,8 @@ def get_subscription_fees(info=None):
 
     """
     url = subscription_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -482,8 +482,8 @@ def get_referrals(info=None):
 
     """
     url = referral_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -497,9 +497,9 @@ def get_day_trades(info=None):
 
     """
     account = load_account_profile(info='account_number')
-    url = daytrades_url(account)
-    data = request_get(url, 'regular')
-    return(filter_data(data, info))
+    url = daytrades_url(account=account)
+    data = request_get(url=url, dataType='regular')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -513,9 +513,9 @@ def get_documents(info=None):
 
     """
     url = documents_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -532,7 +532,7 @@ def download_document(url, name=None, dirpath=None):
     :returns: Returns the data from the get request.
 
     """
-    data = request_document(url)
+    data = request_document(url=url)
 
     print('Writing PDF...', file=get_output())
     if not name:
@@ -576,7 +576,7 @@ def download_all_documents(doctype=None, dirpath=None):
     counter = 0
     for item in documents:
         if doctype == None:
-            data = request_document(item['download_url'])
+            data = request_document(url=item['download_url'])
             if data:
                 name = item['created_at'][0:10] + '-' + \
                     item['type'] + '-' + item['id']
@@ -588,7 +588,7 @@ def download_all_documents(doctype=None, dirpath=None):
                 print('Writing PDF {}...'.format(counter), file=get_output())
         else:
             if item['type'] == doctype:
-                data = request_document(item['download_url'])
+                data = request_document(url=item['download_url'])
                 if data:
                     name = item['created_at'][0:10] + '-' + \
                         item['type'] + '-' + item['id']
@@ -622,8 +622,8 @@ def get_all_watchlists(info=None):
 
     """
     url = watchlists_url()
-    data = request_get(url, 'result')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='result')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -645,9 +645,9 @@ def get_watchlist_by_name(name="My First List", info=None):
         if wl['display_name'] == name:
             watchlist_id = wl['id']
 
-    url = watchlists_url(name)
-    data = request_get(url,'list_id',{'list_id':watchlist_id})
-    return(filter_data(data, info))
+    url = watchlists_url(name=name)
+    data = request_get(url=url,dataType='list_id',payload={'list_id':watchlist_id})
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -661,8 +661,8 @@ def post_symbols_to_watchlist(inputSymbols, name="My First List"):
     :returns: Returns result of the post request.
 
     """
-    symbols = inputs_to_set(inputSymbols)
-    ids = get_instruments_by_symbols(symbols, info='id')
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
+    ids = get_instruments_by_symbols(inputSymbols=symbols, info='id')
     data = []
     #Get id of requested watchlist
     all_watchlists = get_all_watchlists()
@@ -679,8 +679,8 @@ def post_symbols_to_watchlist(inputSymbols, name="My First List"):
                 "operation" : "create"
             }]
         }
-        url = watchlists_url(name, True)
-        data.append(request_post(url, payload, json=True))
+        url = watchlists_url(name=name, add=True)
+        data.append(request_post(url=url, payload=payload, json=True))
 
     return(data)
 
@@ -696,8 +696,8 @@ def delete_symbols_from_watchlist(inputSymbols, name="My First List"):
     :returns: Returns result of the delete request.
 
     """
-    symbols = inputs_to_set(inputSymbols)
-    ids = get_instruments_by_symbols(symbols, info='id')
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
+    ids = get_instruments_by_symbols(inputSymbols=symbols, info='id')
     data = []
 
     #Get id of requested watchlist
@@ -715,8 +715,8 @@ def delete_symbols_from_watchlist(inputSymbols, name="My First List"):
                 "operation" : "delete"
             }]
         }
-        url = watchlists_url(name, True)
-        data.append(request_post(url, payload, json=True))
+        url = watchlists_url(name=name, add=True)
+        data.append(request_post(url=url, payload=payload, json=True))
 
     return(data)
 
@@ -759,11 +759,11 @@ def build_holdings(with_dividends=False):
             continue
 
         try:
-            instrument_data = get_instrument_by_url(item['instrument'])
+            instrument_data = get_instrument_by_url(url=item['instrument'])
             symbol = instrument_data['symbol']
-            fundamental_data = get_fundamentals(symbol)[0]
+            fundamental_data = get_fundamentals(inputSymbols=symbol)[0]
 
-            price = get_latest_price(instrument_data['symbol'])[0]
+            price = get_latest_price(inputSymbols=instrument_data['symbol'])[0]
             quantity = item['quantity']
             equity = float(item['quantity']) * float(price)
             equity_change = (float(quantity) * float(price)) - \
@@ -793,7 +793,7 @@ def build_holdings(with_dividends=False):
                 {'equity_change': "{0:2f}".format(equity_change)})
             holdings[symbol].update({'type': instrument_data['type']})
             holdings[symbol].update(
-                {'name': get_name_by_symbol(symbol)})
+                {'name': get_name_by_symbol(symbol=symbol)})
             holdings[symbol].update({'id': instrument_data['id']})
             holdings[symbol].update({'pe_ratio': fundamental_data['pe_ratio']})
             holdings[symbol].update(
@@ -802,7 +802,7 @@ def build_holdings(with_dividends=False):
             if with_dividends is True:
                 # dividend_data was retrieved earlier
                 holdings[symbol].update(get_dividends_by_instrument(
-                    item['instrument'], dividend_data))
+                    instrument=item['instrument'], dividend_data=dividend_data))
 
         except:
             pass

--- a/robin_stocks/robinhood/crypto.py
+++ b/robin_stocks/robinhood/crypto.py
@@ -22,8 +22,8 @@ def load_crypto_profile(info=None):
 
     """
     url = crypto_account_url()
-    data = request_get(url, 'indexzero')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='indexzero')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -47,8 +47,8 @@ def get_crypto_positions(info=None):
 
     """
     url = crypto_holdings_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 def get_crypto_currency_pairs(info=None):
@@ -72,8 +72,8 @@ def get_crypto_currency_pairs(info=None):
 
     """
     url = crypto_currency_pairs_url()
-    data = request_get(url, 'results')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='results')
+    return(filter_data(data=data, info=info))
 
 
 def get_crypto_info(symbol, info=None):
@@ -99,13 +99,13 @@ def get_crypto_info(symbol, info=None):
 
     """
     url = crypto_currency_pairs_url()
-    data = request_get(url, 'results')
+    data = request_get(url=url, dataType='results')
     data = [x for x in data if x['asset_currency']['code'] == symbol]
     if len(data) > 0:
         data = data[0]
     else:
         data = None
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 SYMBOL_TO_ID_CACHE = {}
@@ -120,7 +120,7 @@ def get_crypto_id(symbol):
     if symbol in SYMBOL_TO_ID_CACHE:
         return SYMBOL_TO_ID_CACHE[symbol]
 
-    id = get_crypto_info(symbol, 'id')
+    id = get_crypto_info(symbol=symbol, info='id')
     if id:
         SYMBOL_TO_ID_CACHE[symbol] = id
     return id
@@ -147,10 +147,10 @@ def get_crypto_quote(symbol, info=None):
                       * volume
  
     """
-    id = get_crypto_info(symbol, info='id')
-    url = crypto_quote_url(id)
-    data = request_get(url)
-    return(filter_data(data, info))
+    id = get_crypto_info(symbol=symbol, info='id')
+    url = crypto_quote_url(id=id)
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -174,9 +174,9 @@ def get_crypto_quote_from_id(id, info=None):
                       * volume
 
     """
-    url = crypto_quote_url(id)
-    data = request_get(url)
-    return(filter_data(data, info))
+    url = crypto_quote_url(id=id)
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -226,13 +226,13 @@ def get_crypto_historicals(symbol, interval='hour', span='week', bounds='24_7', 
         return([None])
 
 
-    symbol = inputs_to_set(symbol)
-    id = get_crypto_info(symbol[0], info='id')
-    url = crypto_historical_url(id)
+    symbol = inputs_to_set(inputSymbols=symbol)
+    id = get_crypto_info(symbol=symbol[0], info='id')
+    url = crypto_historical_url(id=id)
     payload = {'interval': interval,
                'span': span,
                'bounds': bounds}
-    data = request_get(url, 'regular', payload)
+    data = request_get(url=url, dataType='regular', payload=payload)
 
     histData = []
     cryptoSymbol = data['symbol']
@@ -240,4 +240,4 @@ def get_crypto_historicals(symbol, interval='hour', span='week', bounds='24_7', 
         subitem['symbol'] = cryptoSymbol
         histData.append(subitem)
 
-    return(filter_data(histData, info))
+    return(filter_data(data=histData, info=info))

--- a/robin_stocks/robinhood/export.py
+++ b/robin_stocks/robinhood/export.py
@@ -36,7 +36,7 @@ def create_absolute_csv(dir_path, file_name, order_type):
     if not file_name:
         file_name = "{}_orders_{}.csv".format(order_type, date.today().strftime('%b-%d-%Y'))
     else:
-        file_name = fix_file_extension(file_name)
+        file_name = fix_file_extension(file_name=file_name)
     return(Path.joinpath(directory, file_name))
 
 
@@ -50,7 +50,7 @@ def export_completed_stock_orders(dir_path, file_name=None):
     :type file_name: Optional[str]
 
     """
-    file_path = create_absolute_csv(dir_path, file_name, 'stock')
+    file_path = create_absolute_csv(dir_path=dir_path, file_name=file_name, order_type='stock')
     all_orders = get_all_stock_orders()
     with open(file_path, 'w', newline='') as f:
         csv_writer = writer(f)
@@ -68,7 +68,7 @@ def export_completed_stock_orders(dir_path, file_name=None):
             if order['state'] == 'cancelled' and len(order['executions']) > 0:
                 for partial in order['executions']:
                     csv_writer.writerow([
-                        get_symbol_by_url(order['instrument']),
+                        get_symbol_by_url(url=order['instrument']),
                         partial['timestamp'],
                         order['type'],
                         order['side'],
@@ -79,7 +79,7 @@ def export_completed_stock_orders(dir_path, file_name=None):
 
             if order['state'] == 'filled' and order['cancel'] is None:
                 csv_writer.writerow([
-                    get_symbol_by_url(order['instrument']),
+                    get_symbol_by_url(url=order['instrument']),
                     order['last_transaction_at'],
                     order['type'],
                     order['side'],
@@ -99,7 +99,7 @@ def export_completed_crypto_orders(dir_path, file_name=None):
     :type file_name: Optional[str]
 
     """
-    file_path = create_absolute_csv(dir_path, file_name, 'crypto')
+    file_path = create_absolute_csv(dir_path=dir_path, file_name=file_name, order_type='crypto')
     all_orders = get_all_crypto_orders()
     
     with open(file_path, 'w', newline='') as f:
@@ -120,7 +120,7 @@ def export_completed_crypto_orders(dir_path, file_name=None):
                 except KeyError:
                     fees = 0.0
                 csv_writer.writerow([
-                    get_crypto_quote_from_id(order['currency_pair_id'], 'symbol'),
+                    get_crypto_quote_from_id(id=order['currency_pair_id'], info='symbol'),
                     order['last_transaction_at'],
                     order['type'],
                     order['side'],
@@ -141,7 +141,7 @@ def export_completed_option_orders(dir_path, file_name=None):
         :type file_name: Optional[str]
 
     """
-    file_path = create_absolute_csv(dir_path, file_name, 'option')
+    file_path = create_absolute_csv(dir_path=dir_path, file_name=file_name, order_type='option')
     all_orders = get_all_option_orders()
     with open(file_path, 'w', newline='') as f:
         csv_writer = writer(f)
@@ -163,7 +163,7 @@ def export_completed_option_orders(dir_path, file_name=None):
         for order in all_orders:
             if order['state'] == 'filled':
                 for leg in order['legs']:
-                    instrument_data = request_get(leg['option'])
+                    instrument_data = request_get(url=leg['option'])
                     csv_writer.writerow([
                         order['chain_symbol'],
                         instrument_data['expiration_date'],

--- a/robin_stocks/robinhood/helper.py
+++ b/robin_stocks/robinhood/helper.py
@@ -62,9 +62,9 @@ def id_for_stock(symbol):
 
     url = 'https://api.robinhood.com/instruments/'
     payload = {'symbol': symbol}
-    data = request_get(url, 'indexzero', payload)
+    data = request_get(url=url, dataType='indexzero', payload=payload)
 
-    return(filter_data(data, 'id'))
+    return(filter_data(data=data, info='id'))
 
 
 def id_for_chain(symbol):
@@ -84,7 +84,7 @@ def id_for_chain(symbol):
     url = 'https://api.robinhood.com/instruments/'
 
     payload = {'symbol': symbol}
-    data = request_get(url, 'indexzero', payload)
+    data = request_get(url=url, dataType='indexzero', payload=payload)
 
     if data:
         return(data['tradable_chain_id'])
@@ -107,8 +107,8 @@ def id_for_group(symbol):
         return(None)
 
     url = 'https://api.robinhood.com/options/chains/{0}/'.format(
-        id_for_chain(symbol))
-    data = request_get(url)
+        id_for_chain(symbol=symbol))
+    data = request_get(url=url)
     return(data['underlying_instruments'][0]['id'])
 
 
@@ -127,7 +127,7 @@ def id_for_option(symbol, expirationDate, strike, optionType):
 
     """ 
     symbol = symbol.upper()
-    chain_id = id_for_chain(symbol)
+    chain_id = id_for_chain(symbol=symbol)
     payload = {
         'chain_id': chain_id,
         'expiration_dates': expirationDate,
@@ -136,7 +136,7 @@ def id_for_option(symbol, expirationDate, strike, optionType):
         'state': 'active'
     }
     url = 'https://api.robinhood.com/options/instruments/'
-    data = request_get(url, 'pagination', payload)
+    data = request_get(url=url, dataType='pagination', payload=payload)
 
     listOfOptions = [item for item in data if item["expiration_date"] == expirationDate]
     if (len(listOfOptions) == 0):
@@ -194,7 +194,7 @@ def filter_data(data, info):
         elif info in compareDict and type(data) == dict:
             return(data[info])
         else:
-            print(error_argument_not_key_in_dictionary(info), file=get_output())
+            print(error_argument_not_key_in_dictionary(keyword=info), file=get_output())
             return(noneType)
     else:
         return(data)
@@ -343,10 +343,10 @@ def request_post(url, payload=None, timeout=16, json=False, jsonify_data=True):
     res = None
     try:
         if json:
-            update_session('Content-Type', 'application/json')
+            update_session(key='Content-Type', value='application/json')
             res = SESSION.post(url, json=payload, timeout=timeout)
             update_session(
-                'Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')
+                key='Content-Type', value='application/x-www-form-urlencoded; charset=utf-8')
         else:
             res = SESSION.post(url, data=payload, timeout=timeout)
         if res.status_code not in [200, 201, 202, 204, 301, 302, 303, 304, 307, 400, 401, 402, 403]:

--- a/robin_stocks/robinhood/markets.py
+++ b/robin_stocks/robinhood/markets.py
@@ -31,9 +31,9 @@ def get_top_movers_sp500(direction, info=None):
 
     url = movers_sp500_url()
     payload = {'direction': direction}
-    data = request_get(url, 'pagination', payload)
+    data = request_get(url=url, dataType='pagination', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 def get_top_100(info=None):
     """Returns a list of the Top 100 stocks on Robin Hood.
@@ -60,13 +60,13 @@ def get_top_100(info=None):
 
     """
     url = get_100_most_popular_url()
-    data = request_get(url, 'regular')
-    data = filter_data(data, 'instruments')
+    data = request_get(url=url, dataType='regular')
+    data = filter_data(data=data, info='instruments')
 
-    symbols = [get_symbol_by_url(x) for x in data]
-    data = get_quotes(symbols)
+    symbols = [get_symbol_by_url(url=x) for x in data]
+    data = get_quotes(inputSymbols=symbols)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 def get_top_movers(info=None):
     """Returns a list of the Top 20 movers on Robin Hood.
@@ -93,13 +93,13 @@ def get_top_movers(info=None):
 
     """
     url = movers_top_url()
-    data = request_get(url, 'regular')
-    data = filter_data(data, 'instruments')
+    data = request_get(url=url, dataType='regular')
+    data = filter_data(data=data, info='instruments')
 
-    symbols = [get_symbol_by_url(x) for x in data]
-    data = get_quotes(symbols)
+    symbols = [get_symbol_by_url(url=x) for x in data]
+    data = get_quotes(inputSymbols=symbols)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 def get_all_stocks_from_market_tag(tag, info=None):
     """Returns all the stock quote information that matches a tag category.
@@ -127,18 +127,18 @@ def get_all_stocks_from_market_tag(tag, info=None):
                       * instrument
 
     """
-    url = market_category_url(tag)
-    data = request_get(url, 'regular')
-    data = filter_data(data, 'instruments')
+    url = market_category_url(category=tag)
+    data = request_get(url=url, dataType='regular')
+    data = filter_data(data=data, info='instruments')
 
     if not data:
         print('ERROR: "{}" is not a valid tag'.format(tag), file=get_output())
         return [None]
 
-    symbols = [get_symbol_by_url(x) for x in data]
-    data = get_quotes(symbols)
+    symbols = [get_symbol_by_url(url=x) for x in data]
+    data = get_quotes(inputSymbols=symbols)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 def get_markets(info=None):
     """Returns a list of available markets.
@@ -160,8 +160,8 @@ def get_markets(info=None):
 
     """
     url = markets_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 def get_market_today_hours(market, info=None):
     """Returns the opening and closing hours of a specific market for today. Also will tell you if market is
@@ -189,8 +189,8 @@ def get_market_today_hours(market, info=None):
         raise Exception('Not a valid market name. Check get_markets() for a list of market information.')
 
     url = result['todays_hours']
-    data = request_get(url, 'regular')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='regular')
+    return(filter_data(data=data, info=info))
 
 def get_market_next_open_hours(market, info=None):
     """Returns the opening and closing hours for the next open trading day after today. Also will tell you if market is
@@ -212,9 +212,9 @@ def get_market_next_open_hours(market, info=None):
                       * next_open_hours
 
     """
-    url = get_market_today_hours(market, info='next_open_hours')
-    data = request_get(url, 'regular')
-    return(filter_data(data, info))
+    url = get_market_today_hours(market=market, info='next_open_hours')
+    data = request_get(url=url, dataType='regular')
+    return(filter_data(data=data, info=info))
 
 def get_market_next_open_hours_after_date(market, date, info=None):
     """Returns the opening and closing hours for the next open trading day after a date that is specified. Also will tell you if market is
@@ -238,9 +238,9 @@ def get_market_next_open_hours_after_date(market, date, info=None):
                       * next_open_hours
 
     """
-    url = get_market_hours(market, date, info='next_open_hours')
-    data = request_get(url, 'regular')
-    return(filter_data(data, info))
+    url = get_market_hours(market=market, date=date, info='next_open_hours')
+    data = request_get(url=url, dataType='regular')
+    return(filter_data(data=data, info=info))
 
 def get_market_hours(market, date, info=None):
     """Returns the opening and closing hours of a specific market on a specific date. Also will tell you if market is
@@ -264,9 +264,9 @@ def get_market_hours(market, date, info=None):
                       * next_open_hours
 
     """
-    url = market_hours_url(market, date)
-    data = request_get(url, 'regular')
-    return(filter_data(data, info))
+    url = market_hours_url(market=market, date=date)
+    data = request_get(url=url, dataType='regular')
+    return(filter_data(data=data, info=info))
 
 
 def get_currency_pairs(info=None):
@@ -290,5 +290,5 @@ def get_currency_pairs(info=None):
 
     """
     url = currency_url()
-    data = request_get(url, 'results')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='results')
+    return(filter_data(data=data, info=info))

--- a/robin_stocks/robinhood/options.py
+++ b/robin_stocks/robinhood/options.py
@@ -31,8 +31,8 @@ def get_aggregate_positions(info=None):
 
     """
     url = aggregate_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_aggregate_open_positions(info=None):
@@ -46,8 +46,8 @@ def get_aggregate_open_positions(info=None):
     """
     url = aggregate_url()
     payload = {'nonzero': 'True'}
-    data = request_get(url, 'pagination', payload)
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination', payload=payload)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -61,9 +61,9 @@ def get_market_options(info=None):
 
     """
     url = option_orders_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -77,8 +77,8 @@ def get_all_option_positions(info=None):
 
     """
     url = option_positions_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -95,9 +95,9 @@ def get_open_option_positions(account_number=None, info=None):
     """
     url = option_positions_url(account_number=account_number)
     payload = {'nonzero': 'True'}
-    data = request_get(url, 'pagination', payload)
+    data = request_get(url=url, dataType='pagination', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_chains(symbol, info=None):
@@ -117,10 +117,10 @@ def get_chains(symbol, info=None):
         print(message, file=get_output())
         return None
 
-    url = chains_url(symbol)
-    data = request_get(url)
+    url = chains_url(symbol=symbol)
+    data = request_get(url=url)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 @login_required
 def find_tradable_options(symbol, expirationDate=None, strikePrice=None, optionType=None, info=None):
@@ -147,11 +147,11 @@ def find_tradable_options(symbol, expirationDate=None, strikePrice=None, optionT
         return [None]
 
     url = option_instruments_url()
-    if not id_for_chain(symbol):
+    if not id_for_chain(symbol=symbol):
         print("Symbol {} is not valid for finding options.".format(symbol), file=get_output())
         return [None]
 
-    payload = {'chain_id': id_for_chain(symbol),
+    payload = {'chain_id': id_for_chain(symbol=symbol),
                'chain_symbol': symbol,
                'state': 'active'}
 
@@ -162,8 +162,8 @@ def find_tradable_options(symbol, expirationDate=None, strikePrice=None, optionT
     if optionType:
         payload['type'] = optionType
 
-    data = request_get(url, 'pagination', payload)
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination', payload=payload)
+    return(filter_data(data=data, info=info))
 
 @login_required
 def find_options_by_expiration(inputSymbols, expirationDate, optionType=None, info=None):
@@ -182,7 +182,7 @@ def find_options_by_expiration(inputSymbols, expirationDate, optionType=None, in
 
     """
     try:
-        symbols = inputs_to_set(inputSymbols)
+        symbols = inputs_to_set(inputSymbols=inputSymbols)
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
@@ -191,18 +191,18 @@ def find_options_by_expiration(inputSymbols, expirationDate, optionType=None, in
 
     data = []
     for symbol in symbols:
-        allOptions = find_tradable_options(symbol, expirationDate, None, optionType, None)
+        allOptions = find_tradable_options(None, None, symbol=symbol, expirationDate=expirationDate, optionType=optionType)
         filteredOptions = [item for item in allOptions if item.get("expiration_date") == expirationDate]
 
         for item in filteredOptions:
-            marketData = get_option_market_data_by_id(item['id'])
+            marketData = get_option_market_data_by_id(id=item['id'])
             if marketData:
                 item.update(marketData[0])
             write_spinner()
 
         data.extend(filteredOptions)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 @login_required
 def find_options_by_strike(inputSymbols, strikePrice, optionType=None, info=None):
@@ -221,7 +221,7 @@ def find_options_by_strike(inputSymbols, strikePrice, optionType=None, info=None
 
     """
     try:
-        symbols = inputs_to_set(inputSymbols)
+        symbols = inputs_to_set(inputSymbols=inputSymbols)
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
@@ -230,17 +230,17 @@ def find_options_by_strike(inputSymbols, strikePrice, optionType=None, info=None
 
     data = []
     for symbol in symbols:
-        filteredOptions = find_tradable_options(symbol, None, strikePrice, optionType, None)
+        filteredOptions = find_tradable_options(None, None, symbol=symbol, strikePrice=strikePrice, optionType=optionType)
 
         for item in filteredOptions:
-            marketData = get_option_market_data_by_id(item['id'])
+            marketData = get_option_market_data_by_id(id=item['id'])
             if marketData:
                 item.update(marketData[0])
             write_spinner()
 
         data.extend(filteredOptions)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 @login_required
 def find_options_by_expiration_and_strike(inputSymbols, expirationDate, strikePrice, optionType=None, info=None):
@@ -261,7 +261,7 @@ def find_options_by_expiration_and_strike(inputSymbols, expirationDate, strikePr
 
     """
     try:
-        symbols = inputs_to_set(inputSymbols)
+        symbols = inputs_to_set(inputSymbols=inputSymbols)
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
@@ -270,18 +270,18 @@ def find_options_by_expiration_and_strike(inputSymbols, expirationDate, strikePr
 
     data = []
     for symbol in symbols:
-        allOptions = find_tradable_options(symbol, expirationDate, strikePrice, optionType, None)
+        allOptions = find_tradable_options(None, symbol=symbol, expirationDate=expirationDate, strikePrice=strikePrice, optionType=optionType)
         filteredOptions = [item for item in allOptions if item.get("expiration_date") == expirationDate]
 
         for item in filteredOptions:
-            marketData = get_option_market_data_by_id(item['id'])
+            marketData = get_option_market_data_by_id(id=item['id'])
             if marketData:
                 item.update(marketData[0])
             write_spinner()
 
         data.extend(filteredOptions)
 
-    return filter_data(data, info)
+    return filter_data(data=data, info=info)
 
 @login_required
 def find_options_by_specific_profitability(inputSymbols, expirationDate=None, strikePrice=None, optionType=None, typeProfit="chance_of_profit_short", profitFloor=0.0, profitCeiling=1.0, info=None):
@@ -307,7 +307,7 @@ def find_options_by_specific_profitability(inputSymbols, expirationDate=None, st
     If info parameter is provided, a list of strings is returned where the strings are the value of the key that matches info.
 
     """
-    symbols = inputs_to_set(inputSymbols)
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
     data = []
 
     if (typeProfit != "chance_of_profit_short" and typeProfit != "chance_of_profit_long"):
@@ -315,12 +315,12 @@ def find_options_by_specific_profitability(inputSymbols, expirationDate=None, st
         typeProfit = "chance_of_profit_short"
 
     for symbol in symbols:
-        tempData = find_tradable_options(symbol, expirationDate, strikePrice, optionType, info=None)
+        tempData = find_tradable_options(symbol=symbol, expirationDate=expirationDate, strikePrice=strikePrice, optionType=optionType, info=None)
         for option in tempData:
             if expirationDate and option.get("expiration_date") != expirationDate:
                 continue
 
-            market_data = get_option_market_data_by_id(option['id'])
+            market_data = get_option_market_data_by_id(id=option['id'])
             
             if len(market_data):
                 option.update(market_data[0])
@@ -333,7 +333,7 @@ def find_options_by_specific_profitability(inputSymbols, expirationDate=None, st
                 except:
                     pass
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_option_market_data_by_id(id, info=None):
@@ -348,7 +348,7 @@ def get_option_market_data_by_id(id, info=None):
     If info parameter is provided, the value of the key that matches info is extracted.
 
     """
-    instrument = get_option_instrument_data_by_id(id)
+    instrument = get_option_instrument_data_by_id(id=id)
     if instrument is None:
       # e.g. 503 Server Error: Service Unavailable for url: https://api.robinhood.com/options/instruments/d1058013-09a2-4063-b6b0-92717e17d0c0/
       return None  # just return None which the caller can easily check; do NOT use faked empty data, it will only cause future problem
@@ -357,9 +357,9 @@ def get_option_market_data_by_id(id, info=None):
           "instruments" : instrument['url']
       }
       url = marketdata_options_url()
-      data = request_get(url, 'results', payload)
+      data = request_get(url=url, dataType='results', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 @login_required
 def get_option_market_data(inputSymbols, expirationDate, strikePrice, optionType, info=None):
@@ -381,7 +381,7 @@ def get_option_market_data(inputSymbols, expirationDate, strikePrice, optionType
 
     """
     try:
-        symbols = inputs_to_set(inputSymbols)
+        symbols = inputs_to_set(inputSymbols=inputSymbols)
         if optionType:
             optionType = optionType.lower().strip()
     except AttributeError as message:
@@ -390,11 +390,11 @@ def get_option_market_data(inputSymbols, expirationDate, strikePrice, optionType
 
     data = []
     for symbol in symbols:
-        optionID = id_for_option(symbol, expirationDate, strikePrice, optionType)
-        marketData = get_option_market_data_by_id(optionID)
+        optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strikePrice, optionType=optionType)
+        marketData = get_option_market_data_by_id(id=optionID)
         data.append(marketData)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_option_instrument_data_by_id(id, info=None):
@@ -408,9 +408,9 @@ def get_option_instrument_data_by_id(id, info=None):
     If info parameter is provided, the value of the key that matches info is extracted.
 
     """
-    url = option_instruments_url(id)
-    data = request_get(url)
-    return(filter_data(data, info))
+    url = option_instruments_url(id=id)
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 def get_option_instrument_data(symbol, expirationDate, strikePrice, optionType, info=None):
@@ -437,11 +437,11 @@ def get_option_instrument_data(symbol, expirationDate, strikePrice, optionType, 
         print(message, file=get_output())
         return [None]
 
-    optionID = id_for_option(symbol, expirationDate, strikePrice, optionType)
-    url = option_instruments_url(optionID)
-    data = request_get(url)
+    optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strikePrice, optionType=optionType)
+    url = option_instruments_url(id=optionID)
+    data = request_get(url=url)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_option_historicals(symbol, expirationDate, strikePrice, optionType, interval='hour', span='week', bounds='regular', info=None):
@@ -489,13 +489,13 @@ def get_option_historicals(symbol, expirationDate, strikePrice, optionType, inte
         print('ERROR: Bounds must be "extended","regular",or "trading"', file=get_output())
         return([None])
 
-    optionID = id_for_option(symbol, expirationDate, strikePrice, optionType)
+    optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strikePrice, optionType=optionType)
 
-    url = option_historicals_url(optionID)
+    url = option_historicals_url(id=optionID)
     payload = {'span': span,
                'interval': interval,
                'bounds': bounds}
-    data = request_get(url, 'regular', payload)
+    data = request_get(url=url, dataType='regular', payload=payload)
     if (data == None or data == [None]):
         return data
 
@@ -504,4 +504,4 @@ def get_option_historicals(symbol, expirationDate, strikePrice, optionType, inte
         subitem['symbol'] = symbol
         histData.append(subitem)
 
-    return(filter_data(histData, info))
+    return(filter_data(data=histData, info=info))

--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -18,8 +18,8 @@ def get_all_stock_orders(info=None):
 
     """
     url = orders_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -33,8 +33,8 @@ def get_all_option_orders(info=None):
 
     """
     url = option_orders_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -48,8 +48,8 @@ def get_all_crypto_orders(info=None):
 
     """
     url = crypto_orders_url()
-    data = request_get(url, 'pagination')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='pagination')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -63,11 +63,11 @@ def get_all_open_stock_orders(info=None, account_number=None):
 
     """
     url = orders_url(account_number=account_number)
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     data = [item for item in data if item['cancel'] is not None]
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -81,11 +81,11 @@ def get_all_open_option_orders(info=None, account_number=None):
 
     """
     url = option_orders_url(account_number=account_number)
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     data = [item for item in data if item['cancel_url'] is not None]
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -99,11 +99,11 @@ def get_all_open_crypto_orders(info=None):
 
     """
     url = crypto_orders_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     data = [item for item in data if item['cancel_url'] is not None]
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -115,8 +115,8 @@ def get_stock_order_info(orderID):
     :returns: Returns a list of dictionaries of key/value pairs for the order.
 
     """
-    url = orders_url(orderID)
-    data = request_get(url)
+    url = orders_url(orderID=orderID)
+    data = request_get(url=url)
     return(data)
 
 
@@ -129,8 +129,8 @@ def get_option_order_info(order_id):
     :returns: Returns a list of dictionaries of key/value pairs for the order.
 
     """
-    url = option_orders_url(order_id)
-    data = request_get(url)
+    url = option_orders_url(orderID=order_id)
+    data = request_get(url=url)
     return data
 
 
@@ -143,8 +143,8 @@ def get_crypto_order_info(order_id):
     :returns: Returns a list of dictionaries of key/value pairs for the order.
 
     """
-    url = crypto_orders_url(order_id)
-    data = request_get(url)
+    url = crypto_orders_url(orderID=order_id)
+    data = request_get(url=url)
     return data
 
 
@@ -158,7 +158,7 @@ def find_stock_orders(**arguments):
 
     """ 
     url = orders_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     if (len(arguments) == 0):
         return(data)
@@ -169,7 +169,7 @@ def find_stock_orders(**arguments):
 
     if 'symbol' in arguments.keys():
         arguments['instrument'] = get_instruments_by_symbols(
-            arguments['symbol'], info='url')[0]
+            inputSymbols=arguments['symbol'], info='url')[0]
         del arguments['symbol']
 
     if 'quantity' in arguments.keys():
@@ -180,7 +180,7 @@ def find_stock_orders(**arguments):
     for item in data:
         for i, (key, value) in enumerate(arguments.items()):
             if key not in item:
-                print(error_argument_not_key_in_dictionary(key), file=get_output())
+                print(error_argument_not_key_in_dictionary(keyword=key), file=get_output())
                 return([None])
             if value != item[key]:
                 break
@@ -199,8 +199,8 @@ def cancel_stock_order(orderID):
     :returns: Returns the order information for the order that was cancelled.
 
     """ 
-    url = cancel_url(orderID)
-    data = request_post(url)
+    url = cancel_url(url=orderID)
+    data = request_post(url=url)
 
     if data:
         print('Order '+str(orderID)+' cancelled', file=get_output())
@@ -216,8 +216,8 @@ def cancel_option_order(orderID):
     :returns: Returns the order information for the order that was cancelled.
 
     """ 
-    url = option_cancel_url(orderID)
-    data = request_post(url)
+    url = option_cancel_url(id=orderID)
+    data = request_post(url=url)
 
     if data:
         print('Order '+str(orderID)+' cancelled', file=get_output())
@@ -233,8 +233,8 @@ def cancel_crypto_order(orderID):
     :returns: Returns the order information for the order that was cancelled.
 
     """ 
-    url = crypto_cancel_url(orderID)
-    data = request_post(url)
+    url = crypto_cancel_url(id=orderID)
+    data = request_post(url=url)
 
     if data:
         print('Order '+str(orderID)+' cancelled', file=get_output())
@@ -249,12 +249,12 @@ def cancel_all_stock_orders():
 
     """ 
     url = orders_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     data = [item for item in data if item['cancel'] is not None]
 
     for item in data:
-        request_post(item['cancel'])
+        request_post(url=item['cancel'])
 
     print('All Stock Orders Cancelled', file=get_output())
     return(data)
@@ -268,12 +268,12 @@ def cancel_all_option_orders():
 
     """ 
     url = option_orders_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     data = [item for item in data if item['cancel_url'] is not None]
 
     for item in data:
-        request_post(item['cancel_url'])
+        request_post(url=item['cancel_url'])
 
     print('All Option Orders Cancelled', file=get_output())
     return(data)
@@ -287,12 +287,12 @@ def cancel_all_crypto_orders():
 
     """ 
     url = crypto_orders_url()
-    data = request_get(url, 'pagination')
+    data = request_get(url=url, dataType='pagination')
 
     data = [item for item in data if item['cancel_url'] is not None]
 
     for item in data:
-        request_post(item['cancel_url'])
+        request_post(url=item['cancel_url'])
 
     print('All Crypto Orders Cancelled', file=get_output())
     return(data)
@@ -320,7 +320,7 @@ def order_buy_market(symbol, quantity, account_number=None, timeInForce='gtc', e
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", account_number, None, None, timeInForce, extendedHours, jsonify)
+    return order(None, None, symbol=symbol, quantity=quantity, side="buy", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -346,7 +346,7 @@ def order_buy_fractional_by_quantity(symbol, quantity, account_number=None, time
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", account_number, None, None, timeInForce, extendedHours, jsonify)
+    return order(None, None, symbol=symbol, quantity=quantity, side="buy", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -377,10 +377,10 @@ def order_buy_fractional_by_price(symbol, amountInDollars, account_number=None, 
         return None
 
     # turn the money amount into decimal number of shares
-    price = next(iter(get_latest_price(symbol, 'ask_price', extendedHours)), 0.00)
-    fractional_shares = 0 if (price == 0.00) else round_price(amountInDollars/float(price))
-    
-    return order(symbol, fractional_shares, "buy", None, None, account_number,  timeInForce, extendedHours, jsonify, market_hours)
+    price = next(iter(get_latest_price(inputSymbols=symbol, priceType='ask_price', includeExtendedHours=extendedHours)), 0.00)
+    fractional_shares = 0 if (price == 0.00) else round_price(price=amountInDollars/float(price))
+
+    return order(None, None, symbol=symbol, quantity=fractional_shares, side="buy", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify, market_hours=market_hours)
 
 
 @login_required
@@ -406,8 +406,8 @@ def order_buy_limit(symbol, quantity, limitPrice, account_number=None, timeInFor
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "buy", account_number, limitPrice, None, timeInForce, extendedHours, jsonify)
+    """
+    return order(None, symbol=symbol, quantity=quantity, side="buy", account_number=account_number, limitPrice=limitPrice, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -433,8 +433,8 @@ def order_buy_stop_loss(symbol, quantity, stopPrice, account_number=None, timeIn
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "buy", account_number, None, stopPrice, timeInForce, extendedHours, jsonify)
+    """
+    return order(None, symbol=symbol, quantity=quantity, side="buy", account_number=account_number, stopPrice=stopPrice, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -462,8 +462,8 @@ def order_buy_stop_limit(symbol, quantity, limitPrice, stopPrice, account_number
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "buy", account_number, limitPrice, stopPrice, timeInForce, extendedHours, jsonify)
+    """
+    return order(symbol=symbol, quantity=quantity, side="buy", account_number=account_number, limitPrice=limitPrice, stopPrice=stopPrice, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -493,7 +493,7 @@ def order_buy_trailing_stop(symbol, quantity, trailAmount, trailType='percentage
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
     """
-    return order_trailing_stop(symbol, quantity, "buy", trailAmount, trailType, timeInForce, extendedHours, jsonify)
+    return order_trailing_stop(symbol=symbol, quantity=quantity, side="buy", trailAmount=trailAmount, trailType=trailType, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -517,8 +517,8 @@ def order_sell_market(symbol, quantity, account_number=None, timeInForce='gtc', 
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "sell", account_number, None, None, timeInForce, extendedHours, jsonify)
+    """
+    return order(None, None, symbol=symbol, quantity=quantity, side="sell", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -543,8 +543,8 @@ def order_sell_fractional_by_quantity(symbol, quantity, account_number=None, tim
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "sell", None, None, account_number,  timeInForce, extendedHours, jsonify, market_hours)
+    """
+    return order(None, None, symbol=symbol, quantity=quantity, side="sell", account_number=account_number,  timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify, market_hours=market_hours)
 
 
 @login_required
@@ -569,15 +569,15 @@ def order_sell_fractional_by_price(symbol, amountInDollars, account_number=None,
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
+    """
     if amountInDollars < 1:
         print("ERROR: Fractional share price should meet minimum 1.00.", file=get_output())
         return None
     # turn the money amount into decimal number of shares
-    price = next(iter(get_latest_price(symbol, 'bid_price', extendedHours)), 0.00)
-    fractional_shares = 0 if (price == 0.00) else round_price(amountInDollars/float(price))
+    price = next(iter(get_latest_price(inputSymbols=symbol, priceType='bid_price', includeExtendedHours=extendedHours)), 0.00)
+    fractional_shares = 0 if (price == 0.00) else round_price(price=amountInDollars/float(price))
 
-    return order(symbol, fractional_shares, "sell", account_number, None, None, timeInForce, extendedHours, jsonify)
+    return order(None, None, symbol=symbol, quantity=fractional_shares, side="sell", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -603,8 +603,8 @@ def order_sell_limit(symbol, quantity, limitPrice, account_number=None, timeInFo
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "sell", account_number, limitPrice, None, timeInForce, extendedHours, jsonify)
+    """
+    return order(None, symbol=symbol, quantity=quantity, side="sell", account_number=account_number, limitPrice=limitPrice, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -630,8 +630,8 @@ def order_sell_stop_loss(symbol, quantity, stopPrice, account_number=None, timeI
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "sell", account_number, None, stopPrice, timeInForce, extendedHours, jsonify)
+    """
+    return order(None, symbol=symbol, quantity=quantity, side="sell", account_number=account_number, stopPrice=stopPrice, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -659,8 +659,8 @@ def order_sell_stop_limit(symbol, quantity, limitPrice, stopPrice, account_numbe
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order(symbol, quantity, "sell", account_number, limitPrice, stopPrice, timeInForce, extendedHours, jsonify)
+    """
+    return order(symbol=symbol, quantity=quantity, side="sell", account_number=account_number, limitPrice=limitPrice, stopPrice=stopPrice, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -690,7 +690,7 @@ def order_sell_trailing_stop(symbol, quantity, trailAmount, trailType='percentag
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
     """
-    return order_trailing_stop(symbol, quantity, "sell", trailAmount, trailType, timeInForce, extendedHours, jsonify)
+    return order_trailing_stop(symbol=symbol, quantity=quantity, side="sell", trailAmount=trailAmount, trailType=trailType, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -728,7 +728,7 @@ def order_trailing_stop(symbol, quantity, side, trailAmount, trailType='percenta
         print(message)
         return None
 
-    stock_price = round_price(get_latest_price(symbol, extendedHours)[0])
+    stock_price = round_price(price=get_latest_price(inputSymbols=symbol, includeExtendedHours=extendedHours)[0])
 
     # find stop price based on whether trailType is "amount" or "percentage" and whether its buy or sell
     percentage = 0
@@ -743,11 +743,11 @@ def order_trailing_stop(symbol, quantity, side, trailAmount, trailType='percenta
         return None
 
     stopPrice = stock_price + margin if side == "buy" else stock_price - margin
-    stopPrice = round_price(stopPrice)
+    stopPrice = round_price(price=stopPrice)
 
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
-        'instrument': get_instruments_by_symbols(symbol, info='url')[0],
+        'instrument': get_instruments_by_symbols(inputSymbols=symbol, info='url')[0],
         'symbol': symbol,
         'quantity': quantity,
         'ref_id': str(uuid4()),
@@ -761,7 +761,7 @@ def order_trailing_stop(symbol, quantity, side, trailAmount, trailType='percenta
 
     if side == "buy":
         # price should be greater than stopPrice, adding a 5% threshold
-        payload['price'] = round_price(stopPrice * 1.05)
+        payload['price'] = round_price(price=stopPrice * 1.05)
 
     if trailType == 'amount':
         payload['trailing_peg'] = {'type': 'price', 'price': {'amount': trailAmount, 'currency_code': 'USD'}}
@@ -769,7 +769,7 @@ def order_trailing_stop(symbol, quantity, side, trailAmount, trailType='percenta
         payload['trailing_peg'] = {'type': 'percentage', 'percentage': str(percentage)}
 
     url = orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
 
     return (data)
 
@@ -801,7 +801,7 @@ def order(symbol, quantity, side, limitPrice=None, stopPrice=None, account_numbe
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
+    """
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
@@ -817,25 +817,25 @@ def order(symbol, quantity, side, limitPrice=None, stopPrice=None, account_numbe
         priceType = "bid_price"
 
     if limitPrice and stopPrice:
-        price = round_price(limitPrice)
-        stopPrice = round_price(stopPrice)
+        price = round_price(price=limitPrice)
+        stopPrice = round_price(price=stopPrice)
         orderType = "limit"
         trigger = "stop"
     elif limitPrice:
-        price = round_price(limitPrice)
+        price = round_price(price=limitPrice)
         orderType = "limit"
     elif stopPrice:
-        stopPrice = round_price(stopPrice)
+        stopPrice = round_price(price=stopPrice)
         if side == "buy":
             price = stopPrice
         else:
             price = None
         trigger = "stop"
     else:
-        price = round_price(next(iter(get_latest_price(symbol, priceType, extendedHours)), 0.00))
+        price = round_price(price=next(iter(get_latest_price(inputSymbols=symbol, priceType=priceType, includeExtendedHours=extendedHours)), 0.00))
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
-        'instrument': get_instruments_by_symbols(symbol, info='url')[0],
+        'instrument': get_instruments_by_symbols(inputSymbols=symbol, info='url')[0],
         'symbol': symbol,
         'price': price,
         'quantity': quantity,
@@ -852,22 +852,22 @@ def order(symbol, quantity, side, limitPrice=None, stopPrice=None, account_numbe
     # adjust market orders
     if orderType == 'market':
         del payload['stop_price']
-        del payload['extended_hours'] 
-        
+        del payload['extended_hours']
+
     if market_hours == 'regular_hours':
         if side == "buy":
             payload['preset_percent_limit'] = "0.05"
-            payload['type'] = 'limit' 
+            payload['type'] = 'limit'
         # regular market sell
         elif orderType == 'market' and side == 'sell':
-            del payload['price']   
-    elif market_hours == 'all_day_hours': 
-        payload['type'] = 'limit' 
+            del payload['price']
+    elif market_hours == 'all_day_hours':
+        payload['type'] = 'limit'
         payload['quantity']=int(payload['quantity']) # round to integer instead of fractional
-        
+
     url = orders_url()
 
-    data = request_post(url, payload, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, jsonify_data=jsonify)
 
     return(data)
 
@@ -901,7 +901,7 @@ def order_option_credit_spread(price, symbol, quantity, spread, timeInForce='gtc
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
     """
-    return(order_option_spread("credit", price, symbol, quantity, spread, account_number, timeInForce, jsonify))
+    return(order_option_spread(direction="credit", price=price, symbol=symbol, quantity=quantity, spread=spread, account_number=account_number, timeInForce=timeInForce, jsonify=jsonify))
 
 
 @login_required
@@ -933,7 +933,7 @@ def order_option_debit_spread(price, symbol, quantity, spread, timeInForce='gtc'
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
     """
-    return(order_option_spread("debit", price, symbol, quantity, spread, account_number, timeInForce, jsonify))
+    return(order_option_spread(direction="debit", price=price, symbol=symbol, quantity=quantity, spread=spread, account_number=account_number, timeInForce=timeInForce, jsonify=jsonify))
 
 
 @login_required
@@ -966,7 +966,7 @@ def order_option_spread(direction, price, symbol, quantity, spread, account_numb
     :returns: Dictionary that contains information regarding the trading of options, \
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
-    """ 
+    """
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
@@ -974,14 +974,14 @@ def order_option_spread(direction, price, symbol, quantity, spread, account_numb
         return None
     legs = []
     for each in spread:
-        optionID = id_for_option(symbol,
-                                        each['expirationDate'],
-                                        each['strike'],
-                                        each['optionType'])
+        optionID = id_for_option(symbol=symbol,
+                                 expirationDate=each['expirationDate'],
+                                 strike=each['strike'],
+                                 optionType=each['optionType'])
         legs.append({'position_effect': each['effect'],
                      'side': each['action'],
                      'ratio_quantity': 1,
-                     'option': option_instruments_url(optionID)})
+                     'option': option_instruments_url(id=optionID)})
 
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
@@ -998,7 +998,7 @@ def order_option_spread(direction, price, symbol, quantity, spread, account_numb
     }
 
     url = option_orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
 
     return(data)
 
@@ -1034,14 +1034,14 @@ def order_buy_option_limit(positionEffect, creditOrDebit, price, symbol, quantit
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
+    """
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
         print(message, file=get_output())
         return None
 
-    optionID = id_for_option(symbol, expirationDate, strike, optionType)
+    optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strike, optionType=optionType)
 
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
@@ -1049,7 +1049,7 @@ def order_buy_option_limit(positionEffect, creditOrDebit, price, symbol, quantit
         'time_in_force': timeInForce,
         'legs': [
             {'position_effect': positionEffect, 'side': 'buy',
-                'ratio_quantity': 1, 'option': option_instruments_url(optionID)},
+                'ratio_quantity': 1, 'option': option_instruments_url(id=optionID)},
         ],
         'type': 'limit',
         'trigger': 'immediate',
@@ -1061,7 +1061,7 @@ def order_buy_option_limit(positionEffect, creditOrDebit, price, symbol, quantit
     }
 
     url = option_orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
 
     return(data)
 
@@ -1099,14 +1099,14 @@ def order_buy_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stopP
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
+    """
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
         print(message, file=get_output())
         return None
 
-    optionID = id_for_option(symbol, expirationDate, strike, optionType)
+    optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strike, optionType=optionType)
 
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
@@ -1114,7 +1114,7 @@ def order_buy_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stopP
         'time_in_force': timeInForce,
         'legs': [
             {'position_effect': positionEffect, 'side': 'buy',
-                'ratio_quantity': 1, 'option': option_instruments_url(optionID)},
+                'ratio_quantity': 1, 'option': option_instruments_url(id=optionID)},
         ],
         'type': 'limit',
         'trigger': 'stop',
@@ -1127,7 +1127,7 @@ def order_buy_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stopP
     }
 
     url = option_orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
 
     return(data)
 
@@ -1164,14 +1164,14 @@ def order_sell_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stop
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
+    """
     try:
         symbol = symbol.upper().strip()
     except AttributeError as message:
         print(message, file=get_output())
         return None
 
-    optionID = id_for_option(symbol, expirationDate, strike, optionType)
+    optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strike, optionType=optionType)
 
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
@@ -1179,7 +1179,7 @@ def order_sell_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stop
         'time_in_force': timeInForce,
         'legs': [
             {'position_effect': positionEffect, 'side': 'sell',
-                'ratio_quantity': 1, 'option': option_instruments_url(optionID)},
+                'ratio_quantity': 1, 'option': option_instruments_url(id=optionID)},
         ],
         'type': 'limit',
         'trigger': 'stop',
@@ -1192,7 +1192,7 @@ def order_sell_option_stop_limit(positionEffect, creditOrDebit, limitPrice, stop
     }
 
     url = option_orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
 
     return(data)
 
@@ -1235,7 +1235,7 @@ def order_sell_option_limit(positionEffect, creditOrDebit, price, symbol, quanti
         print(message, file=get_output())
         return None
 
-    optionID = id_for_option(symbol, expirationDate, strike, optionType)
+    optionID = id_for_option(symbol=symbol, expirationDate=expirationDate, strike=strike, optionType=optionType)
 
     payload = {
         'account': load_account_profile(account_number=account_number, info='url'),
@@ -1243,7 +1243,7 @@ def order_sell_option_limit(positionEffect, creditOrDebit, price, symbol, quanti
         'time_in_force': timeInForce,
         'legs': [
             {'position_effect': positionEffect, 'side': 'sell',
-                'ratio_quantity': 1, 'option': option_instruments_url(optionID)},
+                'ratio_quantity': 1, 'option': option_instruments_url(id=optionID)},
         ],
         'type': 'limit',
         'trigger': 'immediate',
@@ -1255,7 +1255,7 @@ def order_sell_option_limit(positionEffect, creditOrDebit, price, symbol, quanti
     }
 
     url = option_orders_url()
-    data = request_post(url, payload, json=True, jsonify_data=jsonify)
+    data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
 
     return(data)
 
@@ -1277,8 +1277,8 @@ def order_buy_crypto_by_price(symbol, amountInDollars, timeInForce='gtc', jsonif
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order_crypto(symbol, "buy", amountInDollars, "price", None, timeInForce, jsonify)
+    """
+    return order_crypto(None, symbol=symbol, side="buy", quantityOrPrice=amountInDollars, amountIn="price", timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1298,8 +1298,8 @@ def order_buy_crypto_by_quantity(symbol, quantity, timeInForce='gtc', jsonify=Tr
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order_crypto(symbol, "buy", quantity, "quantity", None, timeInForce, jsonify)
+    """
+    return order_crypto(None, symbol=symbol, side="buy", quantityOrPrice=quantity, amountIn="quantity", timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1321,8 +1321,8 @@ def order_buy_crypto_limit(symbol, quantity, limitPrice, timeInForce='gtc', json
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order_crypto(symbol, "buy", quantity, "quantity", limitPrice, timeInForce, jsonify)
+    """
+    return order_crypto(symbol=symbol, side="buy", quantityOrPrice=quantity, amountIn="quantity", limitPrice=limitPrice, timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1345,7 +1345,7 @@ def order_buy_crypto_limit_by_price(symbol, amountInDollars, limitPrice, timeInF
     the price, and the quantity.
 
     """
-    return order_crypto(symbol, "buy", amountInDollars, "price", limitPrice, timeInForce, jsonify)
+    return order_crypto(symbol=symbol, side="buy", quantityOrPrice=amountInDollars, amountIn="price", limitPrice=limitPrice, timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1365,8 +1365,8 @@ def order_sell_crypto_by_price(symbol, amountInDollars, timeInForce='gtc', jsoni
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order_crypto(symbol, "sell", amountInDollars, "price", None, timeInForce, jsonify)
+    """
+    return order_crypto(None, symbol=symbol, side="sell", quantityOrPrice=amountInDollars, amountIn="price", timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1386,8 +1386,8 @@ def order_sell_crypto_by_quantity(symbol, quantity, timeInForce='gtc', jsonify=T
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
-    """ 
-    return order_crypto(symbol, "sell", quantity, "quantity", None, timeInForce, jsonify)
+    """
+    return order_crypto(None, symbol=symbol, side="sell", quantityOrPrice=quantity, amountIn="quantity", timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1410,7 +1410,7 @@ def order_sell_crypto_limit(symbol, quantity, limitPrice, timeInForce='gtc', jso
     the price, and the quantity.
 
     """
-    return order_crypto(symbol, "sell", quantity, "quantity", limitPrice, timeInForce, jsonify)
+    return order_crypto(symbol=symbol, side="sell", quantityOrPrice=quantity, amountIn="quantity", limitPrice=limitPrice, timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1433,7 +1433,7 @@ def order_sell_crypto_limit_by_price(symbol, amountInDollars, limitPrice, timeIn
     the price, and the quantity.
 
     """
-    return order_crypto(symbol, "sell", amountInDollars, "price", limitPrice, timeInForce, jsonify)
+    return order_crypto(symbol=symbol, side="sell", quantityOrPrice=amountInDollars, amountIn="price", limitPrice=limitPrice, timeInForce=timeInForce, jsonify=jsonify)
 
 
 @login_required
@@ -1466,7 +1466,7 @@ def order_crypto(symbol, side, quantityOrPrice, amountIn="quantity", limitPrice=
         print(message, file=get_output())
         return None
 
-    crypto_id = get_crypto_id(symbol)
+    crypto_id = get_crypto_id(symbol=symbol)
     orderType = "market"
 
     if side == "buy":
@@ -1478,12 +1478,12 @@ def order_crypto(symbol, side, quantityOrPrice, amountIn="quantity", limitPrice=
         price = limitPrice
         orderType = "limit"
     else:
-        price = round_price(get_crypto_quote_from_id(crypto_id, info=priceType))
+        price = round_price(price=get_crypto_quote_from_id(id=crypto_id, info=priceType))
 
     if amountIn == "quantity":
         quantity = quantityOrPrice
     else:
-        quantity = round_price(quantityOrPrice/price)
+        quantity = round_price(price=quantityOrPrice/price)
 
     payload = {
         'account_id': load_crypto_profile(info="id"),
@@ -1501,7 +1501,7 @@ def order_crypto(symbol, side, quantityOrPrice, amountIn="quantity", limitPrice=
     # This is safe because 'ref_id' guards us from duplicate orders
     attempts = 3
     while attempts > 0:
-        data = request_post(url, payload, json=True, jsonify_data=jsonify)
+        data = request_post(url=url, payload=payload, json=True, jsonify_data=jsonify)
         if data is not None:
             break
 

--- a/robin_stocks/robinhood/profiles.py
+++ b/robin_stocks/robinhood/profiles.py
@@ -63,10 +63,10 @@ def load_account_profile(account_number=None, info=None):
     """
     url = account_profile_url(account_number)
     if account_number is not None:
-         data = request_get(url)
+         data = request_get(url=url)
     else:
-        data = request_get(url, 'indexzero')
-    return(filter_data(data, info))
+        data = request_get(url=url, dataType='indexzero')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -96,8 +96,8 @@ def load_basic_profile(info=None):
 
     """
     url = basic_profile_url()
-    data = request_get(url)
-    return(filter_data(data, info))
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -131,8 +131,8 @@ def load_investment_profile(info=None):
 
     """
     url = investment_profile_url()
-    data = request_get(url)
-    return(filter_data(data, info))
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -170,8 +170,8 @@ def load_portfolio_profile(info=None):
 
     """
     url = portfolio_profile_url()
-    data = request_get(url, 'indexzero')
-    return(filter_data(data, info))
+    data = request_get(url=url, dataType='indexzero')
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -203,8 +203,8 @@ def load_security_profile(info=None):
 
     """
     url = security_profile_url()
-    data = request_get(url)
-    return(filter_data(data, info))
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))
 
 
 @login_required
@@ -231,5 +231,5 @@ def load_user_profile(info=None):
 
     """
     url = user_profile_url()
-    data = request_get(url)
-    return(filter_data(data, info))
+    data = request_get(url=url)
+    return(filter_data(data=data, info=info))

--- a/robin_stocks/robinhood/stocks.py
+++ b/robin_stocks/robinhood/stocks.py
@@ -30,21 +30,21 @@ def get_quotes(inputSymbols, info=None):
                       * instrument
 
     """
-    symbols = inputs_to_set(inputSymbols)
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
     url = quotes_url()
     payload = {'symbols': ','.join(symbols)}
-    data = request_get(url, 'results', payload)
+    data = request_get(url=url, dataType='results', payload=payload)
 
     if (data == None or data == [None]):
         return data
 
     for count, item in enumerate(data):
         if item is None:
-            print(error_ticker_does_not_exist(symbols[count]), file=get_output())
+            print(error_ticker_does_not_exist(ticker=symbols[count]), file=get_output())
 
     data = [item for item in data if item is not None]
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_fundamentals(inputSymbols, info=None):
@@ -83,23 +83,23 @@ def get_fundamentals(inputSymbols, info=None):
                       * symbol
 
     """ 
-    symbols = inputs_to_set(inputSymbols)
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
     url = fundamentals_url()
     payload = {'symbols': ','.join(symbols)}
-    data = request_get(url, 'results', payload)
+    data = request_get(url=url, dataType='results', payload=payload)
 
     if (data == None or data == [None]):
         return data
 
     for count, item in enumerate(data):
         if item is None:
-            print(error_ticker_does_not_exist(symbols[count]), file=get_output())
+            print(error_ticker_does_not_exist(ticker=symbols[count]), file=get_output())
         else:
             item['symbol'] = symbols[count]
 
     data = [item for item in data if item is not None]
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_instruments_by_symbols(inputSymbols, info=None):
@@ -138,19 +138,19 @@ def get_instruments_by_symbols(inputSymbols, info=None):
                       * default_collar_fraction
 
     """ 
-    symbols = inputs_to_set(inputSymbols)
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
     url = instruments_url()
     data = []
     for item in symbols:
         payload = {'symbol': item}
-        itemData = request_get(url, 'indexzero', payload)
+        itemData = request_get(url=url, dataType='indexzero', payload=payload)
 
         if itemData:
             data.append(itemData)
         else:
-            print(error_ticker_does_not_exist(item), file=get_output())
+            print(error_ticker_does_not_exist(ticker=item), file=get_output())
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_instrument_by_url(url, info=None):
@@ -190,9 +190,9 @@ def get_instrument_by_url(url, info=None):
                       * default_collar_fraction
 
     """
-    data = request_get(url, 'regular')
+    data = request_get(url=url, dataType='regular')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_latest_price(inputSymbols, priceType=None, includeExtendedHours=True):
@@ -208,8 +208,8 @@ def get_latest_price(inputSymbols, priceType=None, includeExtendedHours=True):
     :returns: [list] A list of prices as strings.
 
     """ 
-    symbols = inputs_to_set(inputSymbols)
-    quote = get_quotes(symbols)
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
+    quote = get_quotes(inputSymbols=symbols)
 
     prices = []
     for item in quote:
@@ -247,13 +247,13 @@ def get_name_by_symbol(symbol):
 
     url = instruments_url()
     payload = {'symbol': symbol}
-    data = request_get(url, 'indexzero', payload)
+    data = request_get(url=url, dataType='indexzero', payload=payload)
     if not data:
         return(None)
     # If stock doesn't have a simple name attribute then get the full name.
-    filter = filter_data(data, info='simple_name')
+    filter = filter_data(data=data, info='simple_name')
     if not filter or filter == "":
-        filter = filter_data(data, info='name')
+        filter = filter_data(data=data, info='name')
     return(filter)
 
 
@@ -268,13 +268,13 @@ def get_name_by_url(url):
     :returns: [str] Returns the simple name of the stock. If the simple name does not exist then returns the full name.
 
     """
-    data = request_get(url)
+    data = request_get(url=url)
     if not data:
         return(None)
     # If stock doesn't have a simple name attribute then get the full name.
-    filter = filter_data(data, info='simple_name')
+    filter = filter_data(data=data, info='simple_name')
     if not filter or filter == "":
-        filter = filter_data(data, info='name')
+        filter = filter_data(data=data, info='name')
     return(filter)
 
 
@@ -289,8 +289,8 @@ def get_symbol_by_url(url):
     :returns: [str] Returns the ticker symbol of the stock.
 
     """
-    data = request_get(url)
-    return filter_data(data, info='symbol')
+    data = request_get(url=url)
+    return filter_data(data=data, info='symbol')
 
 @convert_none_to_string
 def get_ratings(symbol, info=None):
@@ -315,8 +315,8 @@ def get_ratings(symbol, info=None):
         print(message, file=get_output())
         return None
 
-    url = ratings_url(symbol)
-    data = request_get(url)
+    url = ratings_url(symbol=symbol)
+    data = request_get(url=url)
     if not data:
         return(data)
 
@@ -327,7 +327,7 @@ def get_ratings(symbol, info=None):
             oldText = item['text']
             item['text'] = oldText.encode('UTF-8')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
     
 
 def get_events(symbol, info=None):
@@ -365,11 +365,11 @@ def get_events(symbol, info=None):
         print(message, file=get_output())
         return None
 
-    payload = {'equity_instrument_id': id_for_stock(symbol)}
+    payload = {'equity_instrument_id': id_for_stock(symbol=symbol)}
     url = events_url()
-    data = request_get(url, 'results', payload)
+    data = request_get(url=url, dataType='results', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_earnings(symbol, info=None):
@@ -399,9 +399,9 @@ def get_earnings(symbol, info=None):
 
     url = earnings_url()
     payload = {'symbol': symbol}
-    data = request_get(url, 'results', payload)
+    data = request_get(url=url, dataType='results', payload=payload)
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_news(symbol, info=None):
@@ -437,10 +437,10 @@ def get_news(symbol, info=None):
         print(message, file=get_output())
         return None
 
-    url = news_url(symbol)
-    data = request_get(url, 'results')
+    url = news_url(symbol=symbol)
+    data = request_get(url=url, dataType='results')
 
-    return(filter_data(data, info))
+    return(filter_data(data=data, info=info))
 
 
 def get_splits(symbol, info=None):
@@ -467,9 +467,9 @@ def get_splits(symbol, info=None):
         print(message, file=get_output())
         return None
 
-    url = splits_url(symbol)
-    data = request_get(url, 'results')
-    return(filter_data(data, info))
+    url = splits_url(symbol=symbol)
+    data = request_get(url=url, dataType='results')
+    return(filter_data(data=data, info=info))
 
 
 def find_instrument_data(query):
@@ -507,7 +507,7 @@ def find_instrument_data(query):
     url = instruments_url()
     payload = {'query': query}
 
-    data = request_get(url, 'pagination', payload)
+    data = request_get(url=url, dataType='pagination', payload=payload)
 
     if len(data) == 0:
         print('No results found for that keyword', file=get_output())
@@ -561,28 +561,28 @@ def get_stock_historicals(inputSymbols, interval='hour', span='week', bounds='re
         print('ERROR: extended and trading bounds can only be used with a span of "day"', file=get_output())
         return([None])
 
-    symbols = inputs_to_set(inputSymbols)
+    symbols = inputs_to_set(inputSymbols=inputSymbols)
     url = historicals_url()
     payload = {'symbols': ','.join(symbols),
                'interval': interval,
                'span': span,
                'bounds': bounds}
 
-    data = request_get(url, 'results', payload)
+    data = request_get(url=url, dataType='results', payload=payload)
     if (data == None or data == [None]):
         return data
 
     histData = []
     for count, item in enumerate(data):
         if (len(item['historicals']) == 0):
-            print(error_ticker_does_not_exist(symbols[count]), file=get_output())
+            print(error_ticker_does_not_exist(ticker=symbols[count]), file=get_output())
             continue
         stockSymbol = item['symbol']
         for subitem in item['historicals']:
             subitem['symbol'] = stockSymbol
             histData.append(subitem)
 
-    return(filter_data(histData, info))
+    return(filter_data(data=histData, info=info))
 
 
 def get_stock_quote_by_id(stock_id, info=None):
@@ -612,10 +612,10 @@ def get_stock_quote_by_id(stock_id, info=None):
                       * updated_at
                       * instrument
     """
-    url = marketdata_quotes_url(stock_id)
-    data = request_get(url)
+    url = marketdata_quotes_url(id=stock_id)
+    data = request_get(url=url)
 
-    return (filter_data(data, info))
+    return (filter_data(data=data, info=info))
 
 
 def get_stock_quote_by_symbol(symbol, info=None):
@@ -646,7 +646,7 @@ def get_stock_quote_by_symbol(symbol, info=None):
                       * instrument
     """
 
-    return get_stock_quote_by_id(id_for_stock(symbol))
+    return get_stock_quote_by_id(stock_id=id_for_stock(symbol=symbol))
 
 
 def get_pricebook_by_id(stock_id, info=None):
@@ -661,10 +661,10 @@ def get_pricebook_by_id(stock_id, info=None):
     :return: Returns a dictionary of asks and bids.
 
     """
-    url = marketdata_pricebook_url(stock_id)
-    data = request_get(url)
+    url = marketdata_pricebook_url(id=stock_id)
+    data = request_get(url=url)
 
-    return (filter_data(data, info))
+    return (filter_data(data=data, info=info))
 
 
 def get_pricebook_by_symbol(symbol, info=None):
@@ -680,4 +680,4 @@ def get_pricebook_by_symbol(symbol, info=None):
 
     """
 
-    return get_pricebook_by_id(id_for_stock(symbol))
+    return get_pricebook_by_id(stock_id=id_for_stock(symbol=symbol))

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -71,18 +71,18 @@ def news_url(symbol):
 
 
 def popularity_url(symbol):
-    return('https://api.robinhood.com/instruments/{0}/popularity/'.format(id_for_stock(symbol)))
+    return('https://api.robinhood.com/instruments/{0}/popularity/'.format(id_for_stock(symbol=symbol)))
 
 def quotes_url():
     return('https://api.robinhood.com/quotes/')
 
 
 def ratings_url(symbol):
-    return('https://api.robinhood.com/midlands/ratings/{0}/'.format(id_for_stock(symbol)))
+    return('https://api.robinhood.com/midlands/ratings/{0}/'.format(id_for_stock(symbol=symbol)))
 
 
 def splits_url(symbol):
-    return('https://api.robinhood.com/instruments/{0}/splits/'.format(id_for_stock(symbol)))
+    return('https://api.robinhood.com/instruments/{0}/splits/'.format(id_for_stock(symbol=symbol)))
 
 # account
 
@@ -197,7 +197,7 @@ def aggregate_url():
 
 
 def chains_url(symbol):
-    return('https://api.robinhood.com/options/chains/{0}/'.format(id_for_chain(symbol)))
+    return('https://api.robinhood.com/options/chains/{0}/'.format(id_for_chain(symbol=symbol)))
 
 
 def option_historicals_url(id):

--- a/robin_stocks/tda/accounts.py
+++ b/robin_stocks/tda/accounts.py
@@ -24,7 +24,7 @@ def get_accounts(options=None, jsonify=None):
         }
     else:
         payload = None
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -45,14 +45,14 @@ def get_account(id, options=None, jsonify=None):
         or a dictionary parsed using the JSON format and the second entry is an error string or \
         None if there was not an error.
     """
-    url = URLS.account(id)
+    url = URLS.account(id=id)
     if options:
         payload = {
             "fields": options
         }
     else:
         payload = None
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -81,7 +81,7 @@ def get_transactions(id, type_value=None, symbol=None, start_date=None, end_date
         or a dictionary parsed using the JSON format and the second entry is an error string or \
         None if there was not an error.
     """
-    url = URLS.transactions(id)
+    url = URLS.transactions(id=id)
     payload = {}
     if type_value:
         payload["type"] = type_value
@@ -91,7 +91,7 @@ def get_transactions(id, type_value=None, symbol=None, start_date=None, end_date
         payload["startDate"] = start_date
     if end_date:
         payload["endDate"] = end_date
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -111,6 +111,6 @@ def get_transaction(account_id, transaction_id, jsonify=None):
         or a dictionary parsed using the JSON format and the second entry is an error string or \
         None if there was not an error.
     """
-    url = URLS.transaction(account_id, transaction_id)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.transaction(id=account_id, transaction=transaction_id)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error

--- a/robin_stocks/tda/authentication.py
+++ b/robin_stocks/tda/authentication.py
@@ -85,7 +85,7 @@ def login(encryption_passcode):
             "refresh_token": refresh_token,
             "client_id": client_id
         }
-        data, _ = request_data(url, payload, True)
+        data, _ = request_data(url=url, payload=payload, parse_json=True)
         if "access_token" not in data and "refresh_token" not in data:
             raise ValueError(
                 "Refresh token is no longer valid. Call login_first_time() to get a new refresh token.")
@@ -106,7 +106,7 @@ def login(encryption_passcode):
             "refresh_token": refresh_token,
             "client_id": client_id
         }
-        data, _ = request_data(url, payload, True)
+        data, _ = request_data(url=url, payload=payload, parse_json=True)
         if "access_token" not in data:
             raise ValueError(
                 "Refresh token is no longer valid. Call login_first_time() to get a new refresh token.")
@@ -123,9 +123,9 @@ def login(encryption_passcode):
                 }, pickle_file)
     # Store authorization token in session information to be used with API calls.
     auth_token = "Bearer {0}".format(access_token)
-    update_session("Authorization", auth_token)
-    update_session("apikey", client_id)
-    set_login_state(True)
+    update_session(key="Authorization", value=auth_token)
+    update_session(key="apikey", value=client_id)
+    set_login_state(logged_in=True)
     return auth_token
 
 

--- a/robin_stocks/tda/markets.py
+++ b/robin_stocks/tda/markets.py
@@ -26,7 +26,7 @@ def get_hours_for_markets(markets, date, jsonify=None):
         "markets": markets,
         "date": date
     }
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -49,11 +49,11 @@ def get_hours_for_market(market, date, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.market(market)
+    url = URLS.market(market=market)
     payload = {
         "date": date
     }
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -77,10 +77,10 @@ def get_movers(market, direction, change, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.movers(market)
+    url = URLS.movers(index=market)
     payload = {
         "direction": direction,
         "change": change
     }
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error

--- a/robin_stocks/tda/orders.py
+++ b/robin_stocks/tda/orders.py
@@ -21,8 +21,8 @@ def place_order(account_id, order_payload, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.orders(account_id)
-    data, error = request_headers(url, order_payload, jsonify)
+    url = URLS.orders(account_id=account_id)
+    data, error = request_headers(url=url, payload=order_payload, parse_json=jsonify)
     return data, error
 
 
@@ -43,8 +43,8 @@ def cancel_order(account_id, order_id, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.order(account_id, order_id)
-    data, error = request_delete(url, jsonify)
+    url = URLS.order(account_id=account_id, order_id=order_id)
+    data, error = request_delete(url=url, parse_json=jsonify)
     return data, error
 
 
@@ -65,8 +65,8 @@ def get_order(account_id, order_id, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.order(account_id, order_id)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.order(account_id=account_id, order_id=order_id)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -97,7 +97,7 @@ yyyy-MM-dd. 'fromEnteredTime' must also be set.
         None if there was not an error.
 
     """
-    url = URLS.orders(account_id)
+    url = URLS.orders(account_id=account_id)
     payload = {}
     if max_results:
         payload["maxResults"] = max_results
@@ -107,5 +107,5 @@ yyyy-MM-dd. 'fromEnteredTime' must also be set.
         payload["toEnteredTime"] = to_time
     if status:
         payload["status"] = status
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error

--- a/robin_stocks/tda/stocks.py
+++ b/robin_stocks/tda/stocks.py
@@ -17,8 +17,8 @@ def get_quote(ticker, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.quote(ticker)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.quote(ticker=ticker)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -41,7 +41,7 @@ def get_quotes(tickers, jsonify=None):
     payload = {
         "symbol": tickers
     }
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -92,7 +92,7 @@ def get_price_history(ticker, period_type, frequency_type, frequency,
     if (start_date or end_date) and period:
         raise ValueError(
             "If start_date and end_date are provided, period should not be provided.")
-    url = URLS.price_history(ticker)
+    url = URLS.price_history(ticker=ticker)
     payload = {
         "periodType": period_type,
         "frequencyType": frequency_type,
@@ -105,7 +105,7 @@ def get_price_history(ticker, period_type, frequency_type, frequency,
         payload["startDate"] = start_date
     if end_date:
         payload["endDate"] = end_date
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -136,7 +136,7 @@ def search_instruments(ticker_string, projection, jsonify=None):
         "symbol": ticker_string,
         "projection": projection
     }
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error
 
 
@@ -155,8 +155,8 @@ def get_instrument(cusip, jsonify=None):
         None if there was not an error.
 
     """
-    url = URLS.instrument(cusip)
-    data, error = request_get(url, None, jsonify)
+    url = URLS.instrument(cusip=cusip)
+    data, error = request_get(url=url, payload=None, parse_json=jsonify)
     return data, error
 
 
@@ -248,5 +248,5 @@ def get_option_chains(ticker, contract_type="ALL", strike_count="10", include_qu
         payload["interestRate"] = interest_rate
     if days_to_expiration:
         payload["daysToExpiration"] = days_to_expiration
-    data, error = request_get(url, payload, jsonify)
+    data, error = request_get(url=url, payload=payload, parse_json=jsonify)
     return data, error

--- a/robin_stocks/tda/urls.py
+++ b/robin_stocks/tda/urls.py
@@ -42,68 +42,68 @@ class URLS:
     # accounts.py
     @classmethod
     def account(cls, id):
-        return cls.get_base_url(Version.v1) + "accounts/{0}".format(id)
+        return cls.get_base_url(version=Version.v1) + "accounts/{0}".format(id)
 
     @classmethod
     def accounts(cls):
-        return cls.get_base_url(Version.v1) + "accounts"
+        return cls.get_base_url(version=Version.v1) + "accounts"
 
     @classmethod
     def transaction(cls, id, transaction):
-        return cls.get_base_url(Version.v1) + "accounts/{0}/transactions/{1}".format(id, transaction)
+        return cls.get_base_url(version=Version.v1) + "accounts/{0}/transactions/{1}".format(id, transaction)
 
     @classmethod
     def transactions(cls, id):
-        return cls.get_base_url(Version.v1) + "accounts/{0}/transactions".format(id)
+        return cls.get_base_url(version=Version.v1) + "accounts/{0}/transactions".format(id)
 
     # authentication.py
     @classmethod
     def oauth(cls):
-        return cls.get_base_url(Version.v1) + "oauth2/token"
+        return cls.get_base_url(version=Version.v1) + "oauth2/token"
 
     # markets.py
     @classmethod
     def markets(cls):
-        return cls.get_base_url(Version.v1) + "marketdata/hours"
+        return cls.get_base_url(version=Version.v1) + "marketdata/hours"
 
     @classmethod
     def market(cls, market):
-        return cls.get_base_url(Version.v1) + "marketdata/{0}/hours".format(market)
+        return cls.get_base_url(version=Version.v1) + "marketdata/{0}/hours".format(market)
 
     @classmethod
     def movers(cls, index):
-        return cls.get_base_url(Version.v1) + "marketdata/{0}/movers".format(index)
+        return cls.get_base_url(version=Version.v1) + "marketdata/{0}/movers".format(index)
 
     # orders.py
     @classmethod
     def orders(cls, account_id):
-        return cls.get_base_url(Version.v1) + "accounts/{0}/orders".format(account_id)
+        return cls.get_base_url(version=Version.v1) + "accounts/{0}/orders".format(account_id)
 
     @classmethod
     def order(cls, account_id, order_id):
-        return cls.get_base_url(Version.v1) + "accounts/{0}/orders/{1}".format(account_id, order_id)
+        return cls.get_base_url(version=Version.v1) + "accounts/{0}/orders/{1}".format(account_id, order_id)
 
     # stocks.py
     @classmethod
     def instruments(cls):
-        return cls.get_base_url(Version.v1) + "instruments"
+        return cls.get_base_url(version=Version.v1) + "instruments"
 
     @classmethod
     def instrument(cls, cusip):
-        return cls.get_base_url(Version.v1) + "instruments/{0}".format(cusip)
+        return cls.get_base_url(version=Version.v1) + "instruments/{0}".format(cusip)
 
     @classmethod
     def quote(cls, ticker):
-        return cls.get_base_url(Version.v1) + "marketdata/{0}/quotes".format(ticker)
+        return cls.get_base_url(version=Version.v1) + "marketdata/{0}/quotes".format(ticker)
 
     @classmethod
     def quotes(cls):
-        return cls.get_base_url(Version.v1) + "marketdata/quotes"
+        return cls.get_base_url(version=Version.v1) + "marketdata/quotes"
 
     @classmethod
     def price_history(cls, ticker):
-        return cls.get_base_url(Version.v1) + "marketdata/{0}/pricehistory".format(ticker)
+        return cls.get_base_url(version=Version.v1) + "marketdata/{0}/pricehistory".format(ticker)
 
     @classmethod
     def option_chains(cls):
-        return cls.get_base_url(Version.v1) + "marketdata/chains"
+        return cls.get_base_url(version=Version.v1) + "marketdata/chains"

--- a/tda.rst
+++ b/tda.rst
@@ -29,8 +29,8 @@ and a refresh token that is also generated on the TD Ameritrade API website.
 To log in for the first time, execute the following code.
 
 >>> import robin_stocks.tda as tda
->>> tda.login_first_time("my-encryption-passcode", "my-application-consumer-key",
->>>     "my-authroization-token", "my-refresh-token") # ONLY CALL ME ONCE. EVER.
+>>> tda.login_first_time(encryption_passcode="my-encryption-passcode", client_id="my-application-consumer-key",
+>>>     authorization_token="my-authroization-token", refresh_token="my-refresh-token") # ONLY CALL ME ONCE. EVER.
 
 Please be sure that you do not call login_first_time every time you run a script. You run it only once, 
 and then you should delete the code from your python file. A better solution would be to enter the python interpreter 
@@ -41,7 +41,7 @@ and the refresh token is used by robin_stocks to get you a new authentication to
 So, at the start of every TD Ameritrade script or program you write, you should execute the following code.
 
 >>> import robin_stocks.tda as tda
->>> tda.login("my-encryption-passcode") # make sure you have called login_first_time as some point.
+>>> tda.login(encryption_passcode="my-encryption-passcode") # make sure you have called login_first_time as some point.
 
 The login function will use your encryption passcode to decrypt your pickle file, generate a new authorization token 
 if it needs to, and then save your authorization to the requests session information. 

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -9,19 +9,19 @@ load_dotenv()
 class TestAuthentication:
 
     def test_login(self):
-        g.login(os.environ['gemini_account_key'],
-                os.environ['gemini_account_secret'])
+        g.login(api_key=os.environ['gemini_account_key'],
+                secret_key=os.environ['gemini_account_secret'])
         assert g.get_login_state()
 
     def test_logout(self):
-        g.login(os.environ['gemini_account_key'],
-                os.environ['gemini_account_secret'])
+        g.login(api_key=os.environ['gemini_account_key'],
+                secret_key=os.environ['gemini_account_secret'])
         g.logout()
         assert not g.get_login_state()
 
     def test_heartbeat(self):
-        g.login(os.environ['gemini_account_key'],
-                os.environ['gemini_account_secret'])
+        g.login(api_key=os.environ['gemini_account_key'],
+                secret_key=os.environ['gemini_account_secret'])
         response, err = g.heartbeat()
         data = response.json()
         assert err == None
@@ -34,7 +34,7 @@ class TestCrypto:
     ticker = "btcusd"
 
     def test_pubticker_btc(self):
-        response, err = g.get_pubticker(self.ticker)
+        response, err = g.get_pubticker(ticker=self.ticker)
         data = response.json()
         assert err == None
         assert response.status_code == 200
@@ -58,16 +58,16 @@ class TestOrders:
 
     @classmethod
     def setup_class(cls):
-        g.use_sand_box_urls(True)
-        g.login(os.environ['gemini_sandbox_key'],
-                os.environ['gemini_sandbox_secret'])
+        g.use_sand_box_urls(use_sandbox=True)
+        g.login(api_key=os.environ['gemini_sandbox_key'],
+                secret_key=os.environ['gemini_sandbox_secret'])
 
     @classmethod
     def teardown_class(cls):
-        g.use_sand_box_urls(False)
+        g.use_sand_box_urls(use_sandbox=False)
 
     def test_mytrades(self):
-        response, err = g.get_trades_for_crypto("btcusd")
+        response, err = g.get_trades_for_crypto(ticker="btcusd")
         assert err == None
         assert response.status_code == 200
 
@@ -76,8 +76,8 @@ class TestAccount:
 
     @classmethod
     def setup_class(cls):
-        g.login(os.environ['gemini_account_key'],
-                os.environ['gemini_account_secret'])
+        g.login(api_key=os.environ['gemini_account_key'],
+                secret_key=os.environ['gemini_account_secret'])
 
     def test_account_detail(self):
         response, err = g.get_account_detail()

--- a/tests/test_robinhood.py
+++ b/tests/test_robinhood.py
@@ -30,7 +30,7 @@ def third_friday(year, month, day):
 
 
 def round_up_price(ticker, multiplier):
-    price = float(r.get_latest_price(ticker)[0])
+    price = float(r.get_latest_price(inputSymbols=ticker)[0])
     num = price + (multiplier - 1)
     return num - (num % multiplier)
 
@@ -56,11 +56,11 @@ class TestStocks:
         r.logout()
 
     def test_name_apple(self):
-        name = r.get_name_by_symbol('aapl')
+        name = r.get_name_by_symbol(symbol='aapl')
         assert name == "Apple"
 
     def test_quotes(self):
-        quote = r.get_quotes(self.single_stock, info=None)
+        quote = r.get_quotes(inputSymbols=self.single_stock, info=None)
         assert (len(quote) == 1)
         quote = quote[0]
         assert (quote['symbol'] == self.single_stock)
@@ -80,15 +80,15 @@ class TestStocks:
         assert ('updated_at' in quote)
         assert ('instrument' in quote)
         #
-        more_quotes = r.get_quotes(self.list_stocks, info=None)
+        more_quotes = r.get_quotes(inputSymbols=self.list_stocks, info=None)
         assert (len(more_quotes) ==  len(self.list_stocks))
         #
-        fake_quotes = r.get_quotes(self.fake_stocks, info=None)
+        fake_quotes = r.get_quotes(inputSymbols=self.fake_stocks, info=None)
         assert (len(fake_quotes) == 1)
         assert (fake_quotes[0] == None)
 
     def test_fundamentals(self):
-        quote = r.get_fundamentals(self.single_stock, info=None)
+        quote = r.get_fundamentals(inputSymbols=self.single_stock, info=None)
         assert (len(quote) == 1)
         assert (quote[0]['symbol'] == self.single_stock)
         quote = quote[0]
@@ -117,15 +117,15 @@ class TestStocks:
         assert ('year_founded' in quote)
         assert ('symbol' in quote)
         #
-        more_quotes = r.get_fundamentals(self.list_stocks, info=None)
+        more_quotes = r.get_fundamentals(inputSymbols=self.list_stocks, info=None)
         assert (len(more_quotes) == len(self.list_stocks))
         #
-        fake_quotes = r.get_fundamentals(self.fake_stocks, info=None)
+        fake_quotes = r.get_fundamentals(inputSymbols=self.fake_stocks, info=None)
         assert (len(fake_quotes) == 1)
         assert (fake_quotes[0] == None)
 
     def test_instruments(self):
-        quote = r.get_instruments_by_symbols(self.single_stock)
+        quote = r.get_instruments_by_symbols(inputSymbols=self.single_stock)
         assert (len(quote) == 1)
         assert (quote[0]['symbol'] == self.single_stock)
         quote = quote[0]
@@ -154,15 +154,15 @@ class TestStocks:
         assert ('fractional_tradability' in quote)
         assert ('default_collar_fraction' in quote)
         #
-        more_quotes = r.get_fundamentals(self.list_stocks, info=None)
+        more_quotes = r.get_fundamentals(inputSymbols=self.list_stocks, info=None)
         assert (len(more_quotes) == len(self.list_stocks))
         #
-        fake_quotes = r.get_fundamentals(self.fake_stocks, info=None)
+        fake_quotes = r.get_fundamentals(inputSymbols=self.fake_stocks, info=None)
         assert (len(fake_quotes) == 1)
         assert (fake_quotes[0] == None)
 
     def test_instrument_id(self):
-        quote = r.get_instrument_by_url(self.instrument)
+        quote = r.get_instrument_by_url(url=self.instrument)
         assert (quote['symbol'] == self.single_stock)
         assert ('id' in quote)
         assert ('url' in quote)
@@ -190,45 +190,45 @@ class TestStocks:
         assert ('default_collar_fraction' in quote)
 
     def test_latest_price(self):
-        price = r.get_latest_price(self.single_stock)
+        price = r.get_latest_price(inputSymbols=self.single_stock)
         assert (len(price) == 1)
-        more_prices = r.get_latest_price(self.list_stocks)
+        more_prices = r.get_latest_price(inputSymbols=self.list_stocks)
         assert (len(more_prices) == len(self.list_stocks))
-        fake_prices = r.get_latest_price(self.fake_stocks)
+        fake_prices = r.get_latest_price(inputSymbols=self.fake_stocks)
         assert (len(fake_prices) == 1)
         assert (fake_prices[0] == None)
 
     def test_name_by_symbol(self):
-        name = r.get_name_by_symbol(self.single_stock)
+        name = r.get_name_by_symbol(symbol=self.single_stock)
         assert (name == 'Apple')
-        fake_name = r.get_name_by_symbol(self.fake_stock)
+        fake_name = r.get_name_by_symbol(symbol=self.fake_stock)
         assert (fake_name == '')
 
     def test_name_by_url(self):
-        name = r.get_name_by_url(self.instrument)
+        name = r.get_name_by_url(url=self.instrument)
         assert (name == 'Apple')
-        fake_name = r.get_name_by_url(self.fake_instrument)
+        fake_name = r.get_name_by_url(url=self.fake_instrument)
         assert (fake_name == '')
 
     def test_symbol_by_url(self):
-        symbol = r.get_symbol_by_url(self.instrument)
+        symbol = r.get_symbol_by_url(url=self.instrument)
         assert (symbol == self.single_stock)
-        fake_symbol = r.get_symbol_by_url(self.fake_instrument)
+        fake_symbol = r.get_symbol_by_url(url=self.fake_instrument)
         assert (fake_symbol == '')
 
     def test_get_ratings(self):
-        ratings = r.get_ratings(self.single_stock)
+        ratings = r.get_ratings(symbol=self.single_stock)
         assert ('summary' in ratings)
         assert ('ratings' in ratings)
         assert ('instrument_id' in ratings)
         assert ('ratings_published_at' in ratings)
-        fake_ratings = r.get_ratings(self.fake_stock)
+        fake_ratings = r.get_ratings(symbol=self.fake_stock)
         assert (fake_ratings == '')
 
     def test_events(self):
-        event = r.get_events(self.single_stock)
+        event = r.get_events(symbol=self.single_stock)
         assert (len(event) == 0)
-        event = r.get_events(self.event_stock)
+        event = r.get_events(symbol=self.event_stock)
         assert (len(event) != 0)
         event = event[0]
         assert ('account' in event)
@@ -249,7 +249,7 @@ class TestStocks:
         assert ('updated_at' in event)
 
     def test_earning(self):
-        earnings = r.get_earnings(self.single_stock)[0]
+        earnings = r.get_earnings(symbol=self.single_stock)[0]
         assert (earnings['symbol'] == self.single_stock)
         assert ('symbol' in earnings)
         assert ('instrument' in earnings)
@@ -258,11 +258,11 @@ class TestStocks:
         assert ('eps' in earnings)
         assert ('report' in earnings)
         assert ('call' in earnings)
-        fake_earnings = r.get_earnings(self.fake_stock)
+        fake_earnings = r.get_earnings(symbol=self.fake_stock)
         assert (len(fake_earnings) == 0)
 
     def test_news(self):
-        news = r.get_news(self.single_stock)[0]
+        news = r.get_news(symbol=self.single_stock)[0]
         assert ('author' in news)
         assert ('num_clicks' in news)
         assert ('preview_image_url' in news)
@@ -277,21 +277,21 @@ class TestStocks:
         assert ('related_instruments' in news)
         assert ('preview_text' in news)
         assert ('currency_id' in news)
-        fake_news = r.get_news(self.fake_stock)
+        fake_news = r.get_news(symbol=self.fake_stock)
         assert (len(fake_news) == 0)
 
     def test_split(self):
-        split = r.get_splits(self.single_stock)[0]
+        split = r.get_splits(symbol=self.single_stock)[0]
         assert (split['instrument'] == self.instrument)
-        fake_split = r.get_splits(self.fake_stock)
+        fake_split = r.get_splits(symbol=self.fake_stock)
         assert (len(fake_split) == 0)
 
     def test_stock_historicals(self):
-        historicals = r.get_stock_historicals(self.single_stock, interval='hour', span='day', bounds='regular', info=None)
+        historicals = r.get_stock_historicals(inputSymbols=self.single_stock, interval='hour', span='day', bounds='regular', info=None)
         assert (len(historicals) <= 6) # 6 regular hours in a day
-        historicals = r.get_stock_historicals(self.single_stock, interval='hour', span='day', bounds='trading', info=None)
+        historicals = r.get_stock_historicals(inputSymbols=self.single_stock, interval='hour', span='day', bounds='trading', info=None)
         assert (len(historicals) <= 9) # 9 trading hours total in a day
-        historicals = r.get_stock_historicals(self.single_stock, interval='hour', span='day', bounds='extended', info=None)
+        historicals = r.get_stock_historicals(inputSymbols=self.single_stock, interval='hour', span='day', bounds='extended', info=None)
         assert (len(historicals) <= 16) # 16 extended hours total in a day
 
 class TestCrypto:
@@ -306,7 +306,7 @@ class TestCrypto:
     @classmethod
     def setup_class(cls):
         totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
-        login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+        login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], mfa_code=totp)
 
     @classmethod
     def teardown_class(cls):
@@ -345,7 +345,7 @@ class TestCrypto:
         assert (len(fake) == 0)
 
     def test_crypto_info(self):
-        crypto = r.get_crypto_info(self.bitcoin, info=None)
+        crypto = r.get_crypto_info(symbol=self.bitcoin, info=None)
         assert ('asset_currency' in crypto)
         assert ('display_only' in crypto)
         assert ('id' in crypto)
@@ -357,11 +357,11 @@ class TestCrypto:
         assert ('quote_currency' in crypto)
         assert ('symbol' in crypto)
         assert ('tradability' in crypto)
-        crypto = r.get_crypto_info(self.stock, info=None)
+        crypto = r.get_crypto_info(symbol=self.stock, info=None)
         assert (crypto == None)
 
     def test_crypto_quote(self):
-        crypto = r.get_crypto_quote(self.bitcoin, info=None)
+        crypto = r.get_crypto_quote(symbol=self.bitcoin, info=None)
         assert ('ask_price' in crypto)
         assert ('bid_price' in crypto)
         assert ('mark_price' in crypto)
@@ -371,13 +371,13 @@ class TestCrypto:
         assert ('symbol' in crypto)
         assert ('id' in crypto)
         assert ('volume' in crypto)
-        crypto = r.get_crypto_quote(self.stock, info=None)
+        crypto = r.get_crypto_quote(symbol=self.stock, info=None)
         assert (crypto == None)
-        crypto = r.get_crypto_quote(self.fake, info=None)
+        crypto = r.get_crypto_quote(symbol=self.fake, info=None)
         assert (crypto == None)
 
     def test_crypto_historicals(self):
-        crypto = r.get_crypto_historicals(self.bitcoin, 'day', 'week', '24_7', info=None)
+        crypto = r.get_crypto_historicals(symbol=self.bitcoin, interval='day', span='week', bounds='24_7', info=None)
         assert (len(crypto) == 7)
         first_point = crypto[0]
         # check keys
@@ -390,20 +390,20 @@ class TestCrypto:
         assert ('session' in first_point)
         assert ('interpolated' in first_point)
         #
-        crypto = r.get_crypto_historicals(self.bitcoin, 'hour', 'day', 'regular', info=None)
+        crypto = r.get_crypto_historicals(symbol=self.bitcoin, interval='hour', span='day', bounds='regular', info=None)
         assert (len(crypto) <= 6) # 6 regular hours in a day
-        crypto = r.get_crypto_historicals(self.bitcoin, 'hour', 'day', 'trading', info=None)
+        crypto = r.get_crypto_historicals(symbol=self.bitcoin, interval='hour', span='day', bounds='trading', info=None)
         assert (len(crypto) <= 9) # 9 trading hours in a day
-        crypto = r.get_crypto_historicals(self.bitcoin, 'hour', 'day', 'extended', info=None)
+        crypto = r.get_crypto_historicals(symbol=self.bitcoin, interval='hour', span='day', bounds='extended', info=None)
         assert (len(crypto) <= 16) # 16 extended hours in a day
-        crypto = r.get_crypto_historicals(self.bitcoin, 'hour', 'day', '24_7', info=None)
+        crypto = r.get_crypto_historicals(symbol=self.bitcoin, interval='hour', span='day', bounds='24_7', info=None)
         assert (len(crypto) <= 24) # 24 24_7 hours in a day
 
 class TestOptions:
 
     # have to login to use round_up_price
     totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
-    login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+    login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], mfa_code=totp)
     #
     now = datetime.datetime.now() + relativedelta(months=1)
     expiration_date = third_friday(now.year, now.month, now.day).strftime("%Y-%m-%d")
@@ -413,40 +413,40 @@ class TestOptions:
     @classmethod
     def setup_class(cls):
         totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
-        login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+        login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], mfa_code=totp)
 
     @classmethod
     def teardown_class(cls):
         r.logout()
 
     def test_find_tradable_options(self):
-        info = r.find_options_by_expiration(self.symbol, self.expiration_date)
+        info = r.find_options_by_expiration(inputSymbols=self.symbol, expirationDate=self.expiration_date)
         first = info[0]
         assert (first['expiration_date'] == self.expiration_date)
         assert (len(info) > 50)
-        info = r.find_options_by_expiration(self.symbol, self.expiration_date, info='strike_price')
+        info = r.find_options_by_expiration(inputSymbols=self.symbol, expirationDate=self.expiration_date, info='strike_price')
         first = info[0]
         assert (type(first) == str)
         assert (len(info) > 50)
-        info = r.find_options_by_expiration(self.symbol, self.expiration_date, info='expiration_date')
+        info = r.find_options_by_expiration(inputSymbols=self.symbol, expirationDate=self.expiration_date, info='expiration_date')
         assert (len(set(info)) == 1)
 
     def test_find_options_by_strike(self):
-        info = r.find_options_by_strike(self.symbol, self.strike)
+        info = r.find_options_by_strike(inputSymbols=self.symbol, strikePrice=self.strike)
         assert (len(info) >= 24)
-        info = r.find_options_by_strike(self.symbol, self.strike,'call')
+        info = r.find_options_by_strike(inputSymbols=self.symbol, strikePrice=self.strike,optionType='call')
         assert (info[0]['type'] == 'call')
-        info = r.find_options_by_strike(self.symbol, self.strike, info='expiration_date')
+        info = r.find_options_by_strike(inputSymbols=self.symbol, strikePrice=self.strike, info='expiration_date')
         assert (len(set(info)) > 1)
-        info = r.find_options_by_strike(self.symbol, self.strike, info='strike_price')
+        info = r.find_options_by_strike(inputSymbols=self.symbol, strikePrice=self.strike, info='strike_price')
         assert (len(set(info)) == 1)
 
     def test_find_options_by_expiration_and_strike(self):
-        info = r.find_options_by_expiration_and_strike(self.symbol, self.expiration_date, self.strike)
+        info = r.find_options_by_expiration_and_strike(inputSymbols=self.symbol, expirationDate=self.expiration_date, strikePrice=self.strike)
         assert (len(info) == 2)
         assert (info[0]['expiration_date'] == self.expiration_date)
         assert (float(info[0]['strike_price']) == self.strike)
-        info = r.find_options_by_expiration_and_strike(self.symbol, self.expiration_date, self.strike, 'call')
+        info = r.find_options_by_expiration_and_strike(inputSymbols=self.symbol, expirationDate=self.expiration_date, strikePrice=self.strike, optionType='call')
         assert (len(info) == 1)
         assert (info[0]['type'] == 'call')
 
@@ -462,7 +462,7 @@ class TestMarkets:
     @classmethod
     def setup_class(cls):
         totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
-        login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+        login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], mfa_code=totp)
 
     @classmethod
     def teardown_class(cls):
@@ -510,7 +510,7 @@ class TestMarkets:
 
     def test_top_movers_sp500(self):
         # going up
-        movers = r.get_top_movers_sp500('up')
+        movers = r.get_top_movers_sp500(direction='up')
         assert (movers)
         first = movers[0]
         assert ('instrument_url' in first)
@@ -522,13 +522,13 @@ class TestMarkets:
         assert ('market_hours_last_price' in first['price_movement'])
         assert (float(first['price_movement']['market_hours_last_movement_pct']) > 0)
         # going down
-        movers = r.get_top_movers_sp500('down')
+        movers = r.get_top_movers_sp500(direction='down')
         assert (movers)
         first = movers[0]
         assert (float(first['price_movement']['market_hours_last_movement_pct']) < 0)
 
     def test_get_all_stocks_from_market_tag(self):
-        movers = r.get_all_stocks_from_market_tag('technology')
+        movers = r.get_all_stocks_from_market_tag(tag='technology')
         assert (movers)
         first = movers[0]
         assert ('ask_price' in first)
@@ -563,7 +563,7 @@ class TestMarkets:
         assert ('website' in first)
 
     def test_get_market_today_hours(self):
-        market = r.get_market_today_hours(self.nyse)
+        market = r.get_market_today_hours(market=self.nyse)
         assert ('date' in market)
         assert ('is_open' in market)
         assert ('opens_at' in market)
@@ -574,7 +574,7 @@ class TestMarkets:
         assert ('next_open_hours' in market)
 
     def test_get_market_next_open_hours(self):
-        market = r.get_market_next_open_hours(self.amex)
+        market = r.get_market_next_open_hours(market=self.amex)
         assert ('date' in market)
         assert ('is_open' in market)
         assert ('opens_at' in market)
@@ -585,7 +585,7 @@ class TestMarkets:
         assert ('next_open_hours' in market)
 
     def test_get_market_next_open_hours_after_date(self):
-        market = r.get_market_next_open_hours_after_date(self.nasdaq, self.today)
+        market = r.get_market_next_open_hours_after_date(market=self.nasdaq, date=self.today)
         assert ('date' in market)
         assert ('is_open' in market)
         assert ('opens_at' in market)
@@ -596,7 +596,7 @@ class TestMarkets:
         assert ('next_open_hours' in market)
 
     def test_get_market_hours(self):
-        market = r.get_market_hours(self.nasdaq, self.today)
+        market = r.get_market_hours(market=self.nasdaq, date=self.today)
         assert ('date' in market)
         assert ('is_open' in market)
         assert ('opens_at' in market)
@@ -624,19 +624,19 @@ class TestMarkets:
 
     @pytest.mark.xfail()
     def test_market_fail(self):
-        market = r.get_market_hours(self.fake, self.today)
+        market = r.get_market_hours(market=self.fake, date=self.today)
         assert market
 
     @pytest.mark.xfail()
     def test_market_date_fail(self):
-        market = r.get_market_hours(self.nasdaq, self.american_time)
+        market = r.get_market_hours(market=self.nasdaq, date=self.american_time)
         assert market
 
 class TestProfiles:
     @classmethod
     def setup_class(cls):
         totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
-        login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+        login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], mfa_code=totp)
 
     @classmethod
     def teardown_class(cls):
@@ -818,7 +818,7 @@ class TestOrders:
     @classmethod
     def setup_class(cls):
         totp  = pyotp.TOTP(os.environ['robin_mfa']).now()
-        login = r.login(os.environ['robin_username'], os.environ['robin_password'], mfa_code=totp)
+        login = r.login(username=os.environ['robin_username'], password=os.environ['robin_password'], mfa_code=totp)
     
     def test_find_stock_orders(cls):
         def isFloat(f):

--- a/tests/test_tda.py
+++ b/tests/test_tda.py
@@ -9,7 +9,7 @@ load_dotenv()
 class TestAuthentication:
 
     def test_login(self):
-        t.login(os.environ['tda_encryption_passcode'])
+        t.login(encryption_passcode=os.environ['tda_encryption_passcode'])
         assert t.get_login_state()
 
 class TestStocks:
@@ -18,10 +18,10 @@ class TestStocks:
 
     @classmethod
     def setup_class(cls):
-        t.login(os.environ['tda_encryption_passcode'])
+        t.login(encryption_passcode=os.environ['tda_encryption_passcode'])
 
     def test_quote(self):
-        resp, err = t.get_quote(self.ticker)
+        resp, err = t.get_quote(ticker=self.ticker)
         data = resp.json()
         assert resp.status_code == 200
         assert err is None


### PR DESCRIPTION
In order to help in future-proofing this library and help in resolving and identifying bugs, I refactored method calls to use keyword arguments instead of positional arguments for method calls where keyword arguments could be easily deduced (i.e. deduced by name, is a remaining parameters).

Any arguments that lacked a variable name that matched the keyword argument name or couldn't be deduced were shifted to the left and left as positional arguments, all others were directly mapped.