### PR TITLE
Fix order_sell_stop_loss function argument order to resolve TypeError

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -434,7 +434,7 @@ def order_buy_stop_loss(symbol, quantity, stopPrice, account_number=None, timeIn
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", account_number, None, stopPrice, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="buy", limitPrice=None, stopPrice=stopPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify= jsonify)
 
 
 @login_required
@@ -631,7 +631,7 @@ def order_sell_stop_loss(symbol, quantity, stopPrice, account_number=None, timeI
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "sell", account_number, None, stopPrice, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="sell", limitPrice=None, stopPrice=stopPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify= jsonify)
 
 
 @login_required

--- a/tests/test_robinhood.py
+++ b/tests/test_robinhood.py
@@ -836,3 +836,7 @@ class TestOrders:
             assert isFloat(order['cumulative_quantity'])
             if(order['state'] == 'filled'):
                 assert (order['quantity'] == order['cumulative_quantity'])
+
+    def test_stop_loss_order(cls):
+        order_details = r.order_sell_stop_loss()
+        assert ('account_number' in order_details)


### PR DESCRIPTION
- Updated `order_buy_stop_loss` and `order_sell_stop_loss` functions to fix argument order, resolving TypeError.
- Added corresponding tests in the `tests` directory to ensure functionality.
