### PR TITLE
Allow Get All Account Profile Info (Including IRA Numbers)

### DIFF
--- a/robin_stocks/robinhood/profiles.py
+++ b/robin_stocks/robinhood/profiles.py
@@ -4,7 +4,7 @@ from robin_stocks.robinhood.urls import *
 
 
 @login_required
-def load_account_profile(account_number=None, info=None):
+def load_account_profile(account_number=None, info=None, dataType="indexzero"):
     """Gets the information associated with the accounts profile,including day
     trading information and cash being held by Robinhood.
 
@@ -12,6 +12,10 @@ def load_account_profile(account_number=None, info=None):
     :type acccount_number: Optional[str]
     :param info: The name of the key whose value is to be returned from the function.
     :type info: Optional[str]
+    :param dataType: Determines how to filter the data. 'regular' returns the unfiltered data. \
+    'results' will return data['results']. 'pagination' will return data['results'] and append it with any \
+    data that is in data['next']. 'indexzero' will return data['results'][0].
+    :type dataType: Optional[str]
     :returns: The function returns a dictionary of key/value pairs. \
     If a string is passed in to the info parameter, then the function will return \
     a string corresponding to the value of the key whose name matches the info parameter.
@@ -65,7 +69,7 @@ def load_account_profile(account_number=None, info=None):
     if account_number is not None:
          data = request_get(url)
     else:
-        data = request_get(url, 'indexzero')
+        data = request_get(url, dataType)
     return(filter_data(data, info))
 
 

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -18,7 +18,7 @@ def account_profile_url(account_number=None):
     if account_number:
         return('https://api.robinhood.com/accounts/'+account_number)
     else:
-        return('https://api.robinhood.com/accounts/')
+        return('https://api.robinhood.com/accounts/?default_to_all_accounts=true')
 
 
 def basic_profile_url():


### PR DESCRIPTION
I created this to solve the issue I was facing here (https://github.com/jmfernandes/robin_stocks/issues/426). The main issue was that there was no way to retrieve the Robinhood IRA account numbers, despite support for IRAs being added earlier when passing the account number into certain functions (such as `load_account_profile`).

At first, I considered creating a new function to serve this purpose (which is still an option), but I found that it could be accomplished in a simpler manner using the already existing `load_account_profile` function. Before, this function was hardcoded to always return the first item in the data list (the `indexzero` option). This means that only the data for the first account is returned (the individual account) unless the IRA number is hardcoded and passed in manually. These changes tweak the URL so that all accounts are returned, and then the optional value of `dataType` can be used to retrieve the entire result, or by default do what it's already doing. 

TLDR: These changes allow the retrieval of all accounts (Individuals and IRAs) by bubbling up the `dataType` param to `load_account_profile`. Unless a value is specifically assigned to `dataType`, the function acts exactly as it does in the current implementation.