### PR TITLE
Account number optional argument for `export_completed_stock_orders`, `get_all_stock_orders`

### DIFF
--- a/robin_stocks/robinhood/export.py
+++ b/robin_stocks/robinhood/export.py
@@ -41,7 +41,7 @@ def create_absolute_csv(dir_path, file_name, order_type):
 
 
 @login_required
-def export_completed_stock_orders(dir_path, file_name=None):
+def export_completed_stock_orders(dir_path, file_name=None, account_number=None):
     """Write all completed orders to a csv file
 
     :param dir_path: Absolute or relative path to the directory the file will be written.
@@ -51,7 +51,7 @@ def export_completed_stock_orders(dir_path, file_name=None):
 
     """
     file_path = create_absolute_csv(dir_path, file_name, 'stock')
-    all_orders = get_all_stock_orders()
+    all_orders = get_all_stock_orders(account_number=account_number)
     with open(file_path, 'w', newline='') as f:
         csv_writer = writer(f)
         csv_writer.writerow([

--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -8,7 +8,7 @@ from robin_stocks.robinhood.stocks import *
 from robin_stocks.robinhood.urls import *
 
 @login_required
-def get_all_stock_orders(info=None):
+def get_all_stock_orders(info=None, account_number=None):
     """Returns a list of all the orders that have been processed for the account.
 
     :param info: Will filter the results to get a specific value.
@@ -17,7 +17,7 @@ def get_all_stock_orders(info=None):
     a list of strings is returned where the strings are the value of the key that matches info.
 
     """
-    url = orders_url()
+    url = orders_url(account_number=account_number)
     data = request_get(url, 'pagination')
     return(filter_data(data, info))
 


### PR DESCRIPTION
This is a minimal change that allows users to specify the account number when exporting stock orders. This resolves part of #366.