### PR TITLE
Unified transfers

### DIFF
--- a/robin_stocks/robinhood/account.py
+++ b/robin_stocks/robinhood/account.py
@@ -421,6 +421,26 @@ def get_unified_transfers(info=None):
     return(filter_data(data, info))
 
 @login_required
+def get_card_transactions(cardType=None, info=None):
+    """Returns all debit card transactions made on the account
+
+    :param cardType: Will filter the card transaction types. Can be 'pending' or 'settled'.
+    :type cardType: Optional[str]
+    :param info: Will filter the results to get a specific value. 'direction' gives if it was debit or credit.
+    :type info: Optional[str]
+    :returns: Returns a list of dictionaries of key/value pairs for each transfer. If info parameter is provided, \
+    a list of strings is returned where the strings are the value of the key that matches info.
+
+    """
+    payload = None
+    if type:
+        payload = { 'type': type }
+
+    url = cardtransactions_url()
+    data = request_get(url, 'pagination', payload)
+    return(filter_data(data, info))
+
+@login_required
 def get_stock_loan_payments(info=None):
     """Returns a list of loan payments.
 

--- a/robin_stocks/robinhood/account.py
+++ b/robin_stocks/robinhood/account.py
@@ -407,23 +407,17 @@ def get_bank_transfers(direction=None, info=None):
     return(filter_data(data, info))
 
 @login_required
-def get_card_transactions(cardType=None, info=None):
-    """Returns all debit card transactions made on the account
+def get_unified_transfers(info=None):
+    """Returns all transfers made for the account.
 
-    :param cardType: Will filter the card transaction types. Can be 'pending' or 'settled'.
-    :type cardType: Optional[str]
-    :param info: Will filter the results to get a specific value. 'direction' gives if it was debit or credit.
+    :param info: Will filter the results to get a specific value.
     :type info: Optional[str]
     :returns: Returns a list of dictionaries of key/value pairs for each transfer. If info parameter is provided, \
     a list of strings is returned where the strings are the value of the key that matches info.
 
     """
-    payload = None
-    if type:
-        payload = { 'type': type }
-
-    url = cardtransactions_url()
-    data = request_get(url, 'pagination', payload)
+    url = unifiedtransfers_url()
+    data = request_get(url, 'results')
     return(filter_data(data, info))
 
 @login_required

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -104,8 +104,8 @@ def banktransfers_url(direction=None):
     else:
         return('https://api.robinhood.com/ach/transfers/')
 
-def cardtransactions_url():
-   return('https://minerva.robinhood.com/history/transactions/')
+def unifiedtransfers_url():
+   return('https://bonfire.robinhood.com/paymenthub/unified_transfers/')
 
 def daytrades_url(account):
     return('https://api.robinhood.com/accounts/{0}/recent_day_trades/'.format(account))

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -104,6 +104,9 @@ def banktransfers_url(direction=None):
     else:
         return('https://api.robinhood.com/ach/transfers/')
 
+def cardtransactions_url():
+   return('https://minerva.robinhood.com/history/transactions/')
+
 def unifiedtransfers_url():
    return('https://bonfire.robinhood.com/paymenthub/unified_transfers/')
 


### PR DESCRIPTION
Adds a function to get unified transfers. From what I can tell this is currently the only way to get debit/credit transfer info which is how I stumbled across it (trying to calculate total contributions). From what I can tell there is no endpoint similar to `/ach/transfers` or `/wire/transfers` for card related transfers. 

Nevertheless, this PR adds a way to get all transfer types in a single request. The url was found via network tab in browser when viewing `https://robinhood.com/account/transfers` which is how they probably populate the 'Completed Transfers' area of the page.

Example json output with redacted values:
```
[
    {
        "id": "REDACTED",
        "originating_account_id": "REDACTED",
        "originating_account_type": "rhs_account",
        "originating_user_uuid": "REDACTED",
        "receiving_account_id": "REDACTED",
        "receiving_account_type": "debit_card_instrument",
        "receiving_user_uuid": "REDACTED",
        "transfer_type": "debit_card_funding",
        "amount": "350.00",
        "currency": "usd",
        "direction": "pull",
        "state": "completed",
        "record_date": null,
        "ref_id": null,
        "description": null,
        "created_at": "2024-08-02T02:08:48.387434-04:00",
        "updated_at": "2024-08-02T02:08:57.834119-04:00",
        "service_fee": "0.00",
        "service_fee_discount_amount": "0.00",
        "net_amount": "350.00",
        "details": {
            "state": "completed",
            "version": null,
            "transfer_type": "debit_card_funding",
            "clawback_amount": null,
            "purpose": "customer_initiated",
            "gold_deposit_boost": null
        },
        "service_fee_discount_details": [],
        "radar_session_id": null,
        "is_visible_in_history": true,
        "is_owner": true,
        "owner_name": null
    },
    {
        "id": "REDACTED",
        "originating_account_id": "REDACTED",
        "originating_account_type": "rhs_account",
        "originating_user_uuid": "REDACTED",
        "receiving_account_id": "REDACTED",
        "receiving_account_type": "ach_relationship",
        "receiving_user_uuid": "REDACTED",
        "transfer_type": "originated_ach",
        "amount": "25",
        "currency": "usd",
        "direction": "pull",
        "state": "cancelled",
        "record_date": null,
        "ref_id": "",
        "description": "",
        "created_at": "2021-02-02T00:49:36.868072-05:00",
        "updated_at": "2021-02-02T01:01:23.730309-05:00",
        "service_fee": "0.00",
        "service_fee_discount_amount": null,
        "net_amount": "25",
        "details": {
            "account": null,
            "ach_relationship": "https://api.robinhood.com/ach/relationships/REDACTED/",
            "amount": "25.00",
            "cancel": null,
            "created_at": "2021-02-02T05:49:36.868072+00:00",
            "direction": "deposit",
            "early_access_amount": "0.00",
            "expected_landing_date": "2021-02-08",
            "expected_landing_datetime": "2021-02-08T09:00:00-05:00",
            "expected_sweep_at": null,
            "fees": "0.00",
            "id": "REDACTED",
            "ref_id": "REDACTED",
            "rhs_state": "cancelled",
            "scheduled": false,
            "state": "cancelled",
            "status_description": "",
            "updated_at": "2021-02-02T06:01:23.730309+00:00",
            "url": "https://bonfire.robinhood.com/paymenthub/unified_transfers/REDACTED/",
            "investment_schedule_id": null,
            "instant_limit_to_grant": "0.00",
            "is_eligible_for_instant_transfer": false,
            "upsell_id": null,
            "version": "1",
            "transfer_type": "originated_ach",
            "enoki_amount": null,
            "enoki_removal_fee": null,
            "clawback_amount": null,
            "gold_deposit_boost": null
        },
        "service_fee_discount_details": null,
        "radar_session_id": null,
        "is_visible_in_history": true,
        "is_owner": true,
        "owner_name": null
    }
]
```

If there is another way to get debit/credit transfers please either comment or open another PR, but I think this function is still handy for an all-in-one solution.