### PR TITLE
Add support for Custom Pickle Paths

### DIFF
--- a/robin_stocks/robinhood/authentication.py
+++ b/robin_stocks/robinhood/authentication.py
@@ -50,7 +50,7 @@ def respond_to_challenge(challenge_id, sms_code):
     return(request_post(url, payload))
 
 
-def login(username=None, password=None, expiresIn=86400, scope='internal', by_sms=True, store_session=True, mfa_code=None, pickle_name=""):
+def login(username=None, password=None, expiresIn=86400, scope='internal', by_sms=True, store_session=True, mfa_code=None, pickle_path="", pickle_name=""):
     """This function will effectively log the user into robinhood by getting an
     authentication token and saving it to the session header. By default, it
     will store the authentication token in a pickle file and load that value
@@ -73,6 +73,8 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', by_sm
     :type store_session: Optional[boolean]
     :param mfa_code: MFA token if enabled.
     :type mfa_code: Optional[str]
+    :param pickle_path: Allows users to specify the path of the pickle file.
+        Accepts both relative and absolute paths.
     :param pickle_name: Allows users to name Pickle token file in order to switch
         between different accounts without having to re-login every time.
     :returns:  A dictionary with log in information. The 'access_token' keyword contains the access token, and the 'detail' keyword \
@@ -82,6 +84,11 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', by_sm
     device_token = generate_device_token()
     home_dir = os.path.expanduser("~")
     data_dir = os.path.join(home_dir, ".tokens")
+    if pickle_path:
+        if not os.path.isabs(pickle_path):
+            # normalize relative paths
+            pickle_path = os.path.normpath(os.path.join(os.getcwd(), pickle_path))
+        data_dir = pickle_path
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
     creds_file = "robinhood" + pickle_name + ".pickle"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='3.1.2',
+      version='3.1.3',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/x-rst',


### PR DESCRIPTION
This is a small PR that allows a user to choose where to save the robinhood cookies `.pickle` file. If not specified, it defaults to `~/.tokens/` (the current behavior). When defined with an absolute or relative path, it uses that instead.