### PR TITLE
All orders start date parameter

### DIFF
--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -13,6 +13,8 @@ def get_all_stock_orders(info=None, account_number=None):
 
     :param info: Will filter the results to get a specific value.
     :type info: Optional[str]
+    :param start_date: Sets the date of when to start returning orders, returns all orders up to current date and time.
+    :type date: Optional[str] format, should this be sent as a DT object? I believe it's safer to require it to be handed to the function as a string.
     :returns: Returns a list of dictionaries of key/value pairs for each order. If info parameter is provided, \
     a list of strings is returned where the strings are the value of the key that matches info.
 
@@ -28,6 +30,8 @@ def get_all_option_orders(info=None, account_number=None):
 
     :param info: Will filter the results to get a specific value.
     :type info: Optional[str]
+    :param start_date: Sets the date of when to start returning orders, returns all orders up to current date and time.
+    :type date: Optional[str] format, should this be sent as a DT object? I believe it's safer to require it to be handed to the function as a string.
     :returns: Returns a list of dictionaries of key/value pairs for each option order. If info parameter is provided, \
     a list of strings is returned where the strings are the value of the key that matches info.
 

--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -8,7 +8,7 @@ from robin_stocks.robinhood.stocks import *
 from robin_stocks.robinhood.urls import *
 
 @login_required
-def get_all_stock_orders(info=None, account_number=None):
+def get_all_stock_orders(info=None, account_number=None, start_date=None):
     """Returns a list of all the orders that have been processed for the account.
 
     :param info: Will filter the results to get a specific value.
@@ -19,13 +19,13 @@ def get_all_stock_orders(info=None, account_number=None):
     a list of strings is returned where the strings are the value of the key that matches info.
 
     """
-    url = orders_url(account_number=account_number)
+    url = orders_url(account_number=account_number, start_date=start_date)
     data = request_get(url, 'pagination')
     return(filter_data(data, info))
 
 
 @login_required
-def get_all_option_orders(info=None, account_number=None):
+def get_all_option_orders(info=None, account_number=None, start_date=None):
     """Returns a list of all the option orders that have been processed for the account.
 
     :param info: Will filter the results to get a specific value.
@@ -36,7 +36,7 @@ def get_all_option_orders(info=None, account_number=None):
     a list of strings is returned where the strings are the value of the key that matches info.
 
     """
-    url = option_orders_url(account_number=account_number)
+    url = option_orders_url(account_number=account_number, start_date=start_date)
     data = request_get(url, 'pagination')
     return(filter_data(data, info))
 

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -238,7 +238,6 @@ def option_orders_url(orderID=None, account_number=None, start_date=None):
                 url += "?" + value
             else:
                 url += "&" + value
-    print(url)
 
     return url
 
@@ -329,6 +328,5 @@ def orders_url(orderID=None, account_number=None, start_date=None):
                 url += "?" + value
             else:
                 url += "&" + value
-    print(url)
 
     return url

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -226,10 +226,19 @@ def option_orders_url(orderID=None, account_number=None, start_date=None):
     url = 'https://api.robinhood.com/options/orders/'
     if orderID:
         url += '{0}/'.format(orderID)
+    query_build = []
     if account_number:
-        url += ('?account_numbers=' + account_number)
+        query_build.append(f"account_numbers={account_number}")
     if start_date:
-        url += ('?updated_at[gte]=' + start_date)
+        query_build.append(f"updated_at[gte]={start_date}")
+
+    if query_build:
+        for index, value in enumerate(query_build):
+            if index == 0:
+                url += "?" + value
+            else:
+                url += "&" + value
+    print(url)
 
     return url
 
@@ -307,9 +316,19 @@ def orders_url(orderID=None, account_number=None, start_date=None):
     url = 'https://api.robinhood.com/orders/'
     if orderID:
         url += '{0}/'.format(orderID)
+
+    query_build = []
     if account_number:
-        url += ('?account_numbers=' + account_number)    
+        query_build.append(f"account_numbers={account_number}")
     if start_date:
-        url += ('?updated_at[gte]=' + start_date)
+        query_build.append(f"updated_at[gte]={start_date}")
+
+    if query_build:
+        for index, value in enumerate(query_build):
+            if index == 0:
+                url += "?" + value
+            else:
+                url += "&" + value
+    print(url)
 
     return url

--- a/robin_stocks/robinhood/urls.py
+++ b/robin_stocks/robinhood/urls.py
@@ -222,14 +222,17 @@ def option_instruments_url(id=None):
         return('https://api.robinhood.com/options/instruments/')
 
 
-def option_orders_url(orderID=None, account_number=None):
+def option_orders_url(orderID=None, account_number=None, start_date=None):
     url = 'https://api.robinhood.com/options/orders/'
     if orderID:
         url += '{0}/'.format(orderID)
     if account_number:
-        url += ('?account_numbers='+account_number)
+        url += ('?account_numbers=' + account_number)
+    if start_date:
+        url += ('?updated_at[gte]=' + start_date)
 
     return url
+
 
 
 def option_positions_url(account_number):
@@ -300,11 +303,13 @@ def option_cancel_url(id):
     return('https://api.robinhood.com/options/orders/{0}/cancel/'.format(id))
 
 
-def orders_url(orderID=None, account_number=None):
+def orders_url(orderID=None, account_number=None, start_date=None):
     url = 'https://api.robinhood.com/orders/'
     if orderID:
         url += '{0}/'.format(orderID)
     if account_number:
-        url += ('?account_numbers='+account_number)
+        url += ('?account_numbers=' + account_number)    
+    if start_date:
+        url += ('?updated_at[gte]=' + start_date)
 
     return url

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='3.2.1',
+      version='3.3.0',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/x-rst',


### PR DESCRIPTION
Hello, and I'm excited to submit my first pull request. I have discovered that by adding a parameter of `updated_at[gte]=start_date` request URL via the arguments for `option_orders_url()` and `orders_url()`, it is possible to limit the order request by start date, proportionally speeding up the time required to receive a short list of orders. 

I have tested with pytest and confirmed that the results are in an independent test. Results with two different dates are attached. 

If you have any feedback or notes on my contribution process, I would be grateful to know if I submitted everything correctly or not.

<img width="498" alt="RS-order-trim_test_results" src="https://github.com/user-attachments/assets/4bc0bcb7-3501-47cd-a7cf-bb64967fc04d">
