### PR TITLE
alternate fix for #524 - mfa_login requirement in _validate_sherrif_id

### DIFF
--- a/robin_stocks/robinhood/authentication.py
+++ b/robin_stocks/robinhood/authentication.py
@@ -211,6 +211,9 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', by_sm
     return(data)
 
 def _validate_sherrif_id(device_token:str, workflow_id:str,mfa_code:str):
+    if mfa_code == None:
+        mfa_code = input("Please type in the MFA code: ")
+
     url = "https://api.robinhood.com/pathfinder/user_machine/"
     payload = {
         'device_id': device_token,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='3.3.0',
+      version='3.3.01',
       description='A Python wrapper around the Robinhood API',
       long_description=long_description,
       long_description_content_type='text/x-rst',


### PR DESCRIPTION
Fixes robin_stocks.authentication.login() to prompt for an mfa_code if needed during login.