### PR TITLE
Add support for 24 hour market to order_buy_limit and order_sell_limit, Updated all calls to order() to use keyword arguments to be more concise and avoid bugs arising from parameter order

### DIFF
--- a/robin_stocks/robinhood/__init__.py
+++ b/robin_stocks/robinhood/__init__.py
@@ -23,7 +23,7 @@ from .export import (export_completed_crypto_orders,
                      export_completed_option_orders,
                      export_completed_stock_orders)
 from .helper import (filter_data, get_output, request_delete, request_document,
-                     request_get, request_post, set_output, update_session)
+                     request_get, request_post, set_output, update_session, LoginRequiredError)
 from .markets import (get_all_stocks_from_market_tag, get_currency_pairs,
                       get_market_hours, get_market_next_open_hours,
                       get_market_next_open_hours_after_date,

--- a/robin_stocks/robinhood/helper.py
+++ b/robin_stocks/robinhood/helper.py
@@ -5,6 +5,9 @@ from functools import wraps
 import requests
 from robin_stocks.robinhood.globals import LOGGED_IN, OUTPUT, SESSION
 
+class LoginRequiredError(Exception):
+    """Exception raised when a method requires authentication but user is not logged in"""
+    pass
 
 def set_login_state(logged_in):
     """Sets the login state"""
@@ -28,8 +31,7 @@ def login_required(func):
     def login_wrapper(*args, **kwargs):
         global LOGGED_IN
         if not LOGGED_IN:
-            raise Exception('{} can only be called when logged in'.format(
-                func.__name__))
+            raise LoginRequiredError(f'{func.__name__} can only be called when logged in')
         return(func(*args, **kwargs))
     return(login_wrapper)
 

--- a/robin_stocks/robinhood/helper.py
+++ b/robin_stocks/robinhood/helper.py
@@ -45,6 +45,19 @@ def convert_none_to_string(func):
             return("")
     return(string_wrapper)
 
+def stock_for_id(instrument_id):
+    """
+    Takes an instrument id and returns a stock ticker
+
+    :param instrument_id: The instrument id
+    :type instrument_id: str
+    :returns: A string that represents the ticker symbol
+    """
+    url = f"https://api.robinhood.com/instruments/{instrument_id}"
+    payload = None
+    data = request_get(url, 'regular', payload)
+
+    return (filter_data(data, 'symbol'))
 
 def id_for_stock(symbol):
     """Takes a stock ticker and returns the instrument id associated with the stock.

--- a/robin_stocks/robinhood/orders.py
+++ b/robin_stocks/robinhood/orders.py
@@ -324,8 +324,7 @@ def order_buy_market(symbol, quantity, account_number=None, timeInForce='gtc', e
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", None, None, account_number, timeInForce, extendedHours, jsonify)
-
+    return order(symbol=symbol, quantity=quantity, side="buy", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)    
 
 @login_required
 def order_buy_fractional_by_quantity(symbol, quantity, account_number=None, timeInForce='gfd', extendedHours=False, jsonify=True):
@@ -350,7 +349,7 @@ def order_buy_fractional_by_quantity(symbol, quantity, account_number=None, time
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", None, None, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="buy", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -384,11 +383,11 @@ def order_buy_fractional_by_price(symbol, amountInDollars, account_number=None, 
     price = next(iter(get_latest_price(symbol, 'ask_price', extendedHours)), 0.00)
     fractional_shares = 0 if (price == 0.00) else round_price(amountInDollars/float(price))
     
-    return order(symbol, fractional_shares, "buy", None, None, account_number, timeInForce, extendedHours, jsonify, market_hours)
+    return order(symbol=symbol, quantity=fractional_shares, side="buy", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify, market_hours=market_hours)
 
 
 @login_required
-def order_buy_limit(symbol, quantity, limitPrice, account_number=None, timeInForce='gtc', extendedHours=False, jsonify=True):
+def order_buy_limit(symbol, quantity, limitPrice, account_number=None, timeInForce='gtc', extendedHours=False, jsonify=True, market_hours='regular_hours'):
     """Submits a limit order to be executed once a certain price is reached.
 
     :param symbol: The stock ticker of the stock to purchase.
@@ -406,12 +405,14 @@ def order_buy_limit(symbol, quantity, limitPrice, account_number=None, timeInFor
     :type extendedHours: Optional[str]
     :param jsonify: If set to False, function will return the request object which contains status code and headers.
     :type jsonify: Optional[str]
+    :param market_hours: The market hours to use for the order (regular_hours, extended_hours, all_day_hours).
+    :type market_hours: Optional[str]
     :returns: Dictionary that contains information regarding the purchase of stocks, \
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", limitPrice, None, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="buy", limitPrice=limitPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify, market_hours=market_hours)
 
 
 @login_required
@@ -438,7 +439,7 @@ def order_buy_stop_loss(symbol, quantity, stopPrice, account_number=None, timeIn
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", None, stopPrice, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="buy", stopPrice=stopPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -467,7 +468,7 @@ def order_buy_stop_limit(symbol, quantity, limitPrice, stopPrice, account_number
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "buy", limitPrice, stopPrice, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="buy", limitPrice=limitPrice, stopPrice=stopPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -497,7 +498,7 @@ def order_buy_trailing_stop(symbol, quantity, trailAmount, trailType='percentage
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
     """
-    return order_trailing_stop(symbol, quantity, "buy", trailAmount, trailType, None, timeInForce, extendedHours, jsonify)
+    return order_trailing_stop(symbol=symbol, quantity=quantity, side="buy", trailAmount=trailAmount, trailType=trailType, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -522,7 +523,7 @@ def order_sell_market(symbol, quantity, account_number=None, timeInForce='gtc', 
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "sell", None, None, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="sell", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -548,7 +549,7 @@ def order_sell_fractional_by_quantity(symbol, quantity, account_number=None, tim
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "sell", None, None, account_number, timeInForce, extendedHours, jsonify, market_hours)
+    return order(symbol=symbol, quantity=quantity, side="sell", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify, market_hours=market_hours)
 
 
 @login_required
@@ -581,11 +582,11 @@ def order_sell_fractional_by_price(symbol, amountInDollars, account_number=None,
     price = next(iter(get_latest_price(symbol, 'bid_price', extendedHours)), 0.00)
     fractional_shares = 0 if (price == 0.00) else round_price(amountInDollars/float(price))
 
-    return order(symbol, fractional_shares, "sell", None, None, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=fractional_shares, side="sell", account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
-def order_sell_limit(symbol, quantity, limitPrice, account_number=None, timeInForce='gtc', extendedHours=False, jsonify=True):
+def order_sell_limit(symbol, quantity, limitPrice, account_number=None, timeInForce='gtc', extendedHours=False, jsonify=True, market_hours='regular_hours'):
     """Submits a limit order to be executed once a certain price is reached.
 
     :param symbol: The stock ticker of the stock to sell.
@@ -603,12 +604,14 @@ def order_sell_limit(symbol, quantity, limitPrice, account_number=None, timeInFo
     :type extendedHours: Optional[str]
     :param jsonify: If set to False, function will return the request object which contains status code and headers.
     :type jsonify: Optional[str]
+    :param market_hours: The market hours to use for the order (regular_hours, extended_hours, all_day_hours).
+    :type market_hours: Optional[str]
     :returns: Dictionary that contains information regarding the selling of stocks, \
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "sell", limitPrice, None, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="sell", limitPrice=limitPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify, market_hours=market_hours)
 
 
 @login_required
@@ -635,7 +638,7 @@ def order_sell_stop_loss(symbol, quantity, stopPrice, account_number=None, timeI
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "sell", None, stopPrice, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="sell", stopPrice=stopPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -664,7 +667,7 @@ def order_sell_stop_limit(symbol, quantity, limitPrice, stopPrice, account_numbe
     the price, and the quantity.
 
     """ 
-    return order(symbol, quantity, "sell", limitPrice, stopPrice, account_number, timeInForce, extendedHours, jsonify)
+    return order(symbol=symbol, quantity=quantity, side="sell", limitPrice=limitPrice, stopPrice=stopPrice, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required
@@ -694,7 +697,7 @@ def order_sell_trailing_stop(symbol, quantity, trailAmount, trailType='percentag
     such as the order id, the state of order (queued, confired, filled, failed, canceled, etc.), \
     the price, and the quantity.
     """
-    return order_trailing_stop(symbol, quantity, "sell", trailAmount, trailType, None, timeInForce, extendedHours, jsonify)
+    return order_trailing_stop(symbol=symbol, quantity=quantity, side="sell", trailAmount=trailAmount, trailType=trailType, account_number=account_number, timeInForce=timeInForce, extendedHours=extendedHours, jsonify=jsonify)
 
 
 @login_required

--- a/robin_stocks/robinhood/stocks.py
+++ b/robin_stocks/robinhood/stocks.py
@@ -4,13 +4,15 @@ from functools import lru_cache as cache
 from robin_stocks.robinhood.helper import *
 from robin_stocks.robinhood.urls import *
 
-def get_quotes(inputSymbols, info=None):
+def get_quotes(inputSymbols, info=None, bounds=None):
     """Takes any number of stock tickers and returns information pertaining to its price.
 
     :param inputSymbols: May be a single stock ticker or a list of stock tickers.
     :type inputSymbols: str or list
     :param info: Will filter the results to have a list of the values that correspond to key that matches info.
     :type info: Optional[str]
+    :param bounds: The bounds to use for the quotes ('24_5' for 24 hour market).
+    :type bounds: Optional[str]
     :returns: [list] If info parameter is left as None then the list will contain a dictionary of key/value pairs for each ticker. \
     Otherwise, it will be a list of strings where the strings are the values of the key that corresponds to info.
     :Dictionary Keys: * ask_price
@@ -33,6 +35,8 @@ def get_quotes(inputSymbols, info=None):
     symbols = inputs_to_set(inputSymbols)
     url = quotes_url()
     payload = {'symbols': ','.join(symbols)}
+    if bounds:
+        payload['bounds'] = bounds
     data = request_get(url, 'results', payload)
 
     if (data == None or data == [None]):


### PR DESCRIPTION
24 hour market supports limit orders, but order_buy_limit() and order_sell_limit() did not provide a way to specify the market hours.

Additionally, made all calls to order() use keyword arguments to avoid bugs that arise from incorrect parameter order