### PR TITLE
authentication: fix login(store_session=False)

### DIFF
--- a/robin_stocks/robinhood/authentication.py
+++ b/robin_stocks/robinhood/authentication.py
@@ -216,7 +216,9 @@ def login(username=None, password=None, expiresIn=86400, scope='internal', store
                                  'access_token': data['access_token'],
                                  'refresh_token': data['refresh_token'],
                                  'device_token': login_payload['device_token']}, f)
-                return data
+
+            return data
+
         except Exception as e:
             print(f"Error during login verification: {e}")
 


### PR DESCRIPTION
dfcf055ca3ff45ec92f357bcb5a36b1696577784 broke `login()` for `store_session=False` by only `return`ing `data` `if store_session` is truthy, and returning `None` with an error message* despite a successful login `if store_session` is falsy.

\* `"Login failed. Check credentials and try again."`

To fix this, I have simply unindented `return data` here, to make sure that it gets returned regardless of `store_session`'s value, and to avoid proceeding to the error message if no exception occurs during login (implying success).