### PR TITLE
Add optional MCP server exposing the SDK as Model Context Protocol tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Robin-Stocks API Library
 ========================
 This library provides a pure Python interface that interacts with the Robinhood API, Gemini API,
 and TD Ameritrade API. The code is simple to use, easy to understand, and easy to modify.
-With this library, you can view information on stocks, options, and crypto-currencies in real-time, 
+With this library, you can view information on stocks, options, and crypto-currencies in real-time,
 create your own robo-investor or trading algorithm, and improve your programming skills.
 
 To join our Slack channel where you can discuss trading and coding, click the link https://join.slack.com/t/robin-stocks/shared_invite/zt-7up2htza-wNSil5YDa3zrAglFFSxRIA
@@ -22,7 +22,7 @@ Below are examples of how to call each of those modules.
 >>> # Here are some example calls
 >>> gem.get_pubticker("btcusd") # gets ticker information for Bitcoin from Gemini
 >>> rh.get_all_open_crypto_orders() # gets all cypto orders from Robinhood
->>> tda.get_price_history("tsla") # get price history from TD Ameritrade 
+>>> tda.get_price_history("tsla") # get price history from TD Ameritrade
 
 Contributing
 ============
@@ -72,18 +72,222 @@ and this will install whatever you changed in the local files. This will allow y
 List of Functions and Example Usage
 ===================================
 
-For a complete list of all Robinhood API functions and what the different parameters mean, 
+For a complete list of all Robinhood API functions and what the different parameters mean,
 go to `readthedocs.io Robinhood Page <https://robin-stocks.readthedocs.io/en/latest/robinhood.html>`_. If you would like to
 see some example code and instructions on how to set up two-factor authorization for Robinhood,
 go to the `Robinhood Documentation`_.
 
-For a complete list of all TD Ameritrade API functions and what the different parameters mean, 
-go to `readthedocs.io TDA Page <https://robin-stocks.readthedocs.io/en/latest/tda.html>`_. For detailed instructions on 
+For a complete list of all TD Ameritrade API functions and what the different parameters mean,
+go to `readthedocs.io TDA Page <https://robin-stocks.readthedocs.io/en/latest/tda.html>`_. For detailed instructions on
 how to generate API keys for TD Ameritrade and how to use the API, go to the `TDA Documentation`_.
 
-For a complete list of all Gemini API functions and what the different parameters mean, 
-go to `readthedocs.io Gemini Page <https://robin-stocks.readthedocs.io/en/latest/gemini.html>`_. For detailed instructions on 
+For a complete list of all Gemini API functions and what the different parameters mean,
+go to `readthedocs.io Gemini Page <https://robin-stocks.readthedocs.io/en/latest/gemini.html>`_. For detailed instructions on
 how to generate API keys for Gemini and how to use both the private and public API, go to the `Gemini Documentation`_.
+
+MCP Server
+==========
+This repo also ships an `MCP <https://modelcontextprotocol.io>`_ server that exposes
+the entire ``robin_stocks`` SDK (Robinhood, TD Ameritrade, Gemini) as **188 tools**
+usable from any MCP client — Claude Code, Claude Desktop, Continue, Cursor, custom
+agents, etc.
+
+Highlights
+^^^^^^^^^^
+
+- 188 tools — 143 Robinhood, 20 TDA, 25 Gemini — prefixed ``rh_*`` / ``tda_*`` / ``gem_*``.
+- **Read-only by default.** Order placement, cancellation, money transfers, watchlist
+  mutations, and file exports return a structured ``ReadOnlyError`` until you
+  explicitly set ``ROBIN_STOCKS_MCP_READ_ONLY=false``.
+- Auto-login from environment variables at startup. TOTP secrets in
+  ``ROBINHOOD_MFA_CODE`` are expanded to the current 6-digit code automatically.
+- Blocking SDK calls are offloaded to a thread pool so the MCP event loop stays
+  responsive.
+- Every tool catches exceptions and returns ``{"error": True, "type", "message"}``
+  payloads instead of crashing the transport.
+
+Install
+^^^^^^^
+
+From a clone of this repo::
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -e ".[mcp]"
+
+That installs the bundled local ``robin_stocks`` SDK plus the new
+``robin_stocks_mcp`` package and the ``mcp[cli]`` runtime, and registers a
+``robin-stocks-mcp`` console script.
+
+First-time setup (interactive — one time only)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The MCP server leans on the SDK's own credential persistence — there is no
+plaintext ``.env`` involved by default. Run the appropriate setup command for
+each broker you want, then forget about it::
+
+    robin-stocks-mcp login        # Robinhood — writes ~/.tokens/robinhood.pickle
+    robin-stocks-mcp tda-setup    # TDA — encrypts client_id + tokens to disk
+
+The Robinhood pickle is reused on every later run; no username/password is
+required again until the token expires. TDA needs the encryption passcode you
+chose during ``tda-setup`` to unlock the credential store — pass it via the
+``tda_login`` MCP tool or set ``TDA_ENCRYPTION_PASSCODE`` in the environment.
+
+Gemini's SDK has no on-disk persistence, so you must provide API keys either
+via the ``gem_login`` MCP tool or via ``GEMINI_API_KEY`` / ``GEMINI_SECRET_KEY``.
+
+Run locally
+^^^^^^^^^^^
+
+::
+
+    robin-stocks-mcp                                # stdio (the implicit `serve`)
+    robin-stocks-mcp serve --transport stdio        # explicit form
+    robin-stocks-mcp serve --transport sse
+    robin-stocks-mcp serve --transport streamable-http
+
+Connect from Claude Code
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+After you have run ``robin-stocks-mcp login`` once, wiring it into Claude Code
+is a one-liner — no credentials in the command::
+
+    claude mcp add robin-stocks "$PWD/.venv/bin/robin-stocks-mcp"
+
+Add ``--scope user`` to make the server available across every Claude Code
+project on this machine, or ``--scope project`` to commit a ``.mcp.json`` to
+the repo so teammates pick it up. To allow order placement, append
+``--env ROBIN_STOCKS_MCP_READ_ONLY=false`` (default is read-only).
+
+Verify it loaded::
+
+    claude mcp list
+
+In a Claude Code session you can also type ``/mcp`` to see live status, or
+just ask "what robin-stocks tools do you have?".
+
+Connect from Claude Desktop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add an entry to your Claude Desktop config
+(``~/Library/Application Support/Claude/claude_desktop_config.json`` on macOS,
+``%APPDATA%\Claude\claude_desktop_config.json`` on Windows), replace the path
+with your checkout, and restart Claude Desktop::
+
+    {
+      "mcpServers": {
+        "robin-stocks": {
+          "command": "/ABSOLUTE/PATH/TO/robin_stocks-mcp/.venv/bin/robin-stocks-mcp",
+          "args": ["serve", "--transport", "stdio"],
+          "env": { "ROBIN_STOCKS_MCP_READ_ONLY": "true" }
+        }
+      }
+    }
+
+No credentials in the config — the server reads the pickle that
+``robin-stocks-mcp login`` wrote. To allow order placement, change the
+``ROBIN_STOCKS_MCP_READ_ONLY`` value to ``"false"``.
+
+Non-interactive setups (CI, containers)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you cannot run the interactive setup commands, create a ``.env`` file in
+the repo root (loaded automatically via ``python-dotenv``) and set whichever
+of the following apply:
+
+=================================  ===========================================
+Variable                           Purpose
+=================================  ===========================================
+``ROBIN_STOCKS_MCP_READ_ONLY``     ``true`` (default) blocks all write tools.
+``ROBIN_STOCKS_MCP_AUTO_LOGIN``    ``true`` (default) enables startup login.
+``ROBINHOOD_USERNAME``             Used only if ``~/.tokens/robinhood.pickle``
+                                   is missing or invalid.
+``ROBINHOOD_PASSWORD``             Same.
+``ROBINHOOD_MFA_CODE``             6-digit code OR a base32 TOTP secret
+                                   (auto-expanded).
+``TDA_ENCRYPTION_PASSCODE``        Passcode that unlocks the encrypted TDA
+                                   credential store.
+``GEMINI_API_KEY``                 Gemini API key.
+``GEMINI_SECRET_KEY``              Gemini API secret.
+``GEMINI_SANDBOX``                 ``true`` to point the SDK at Gemini's
+                                   sandbox.
+=================================  ===========================================
+
+Don't reuse ``.test.env`` for this — that file is specifically for upstream's
+pytest fixtures and uses different (lowercase) keys.
+
+Tool surface (sample)
+^^^^^^^^^^^^^^^^^^^^^
+
+================================================  ===============================================
+Tool                                              What it does
+================================================  ===============================================
+``rh_login`` / ``rh_logout``                      Robinhood auth
+``rh_get_quotes``                                 Quote info for tickers
+``rh_get_latest_price``                           Latest price string per ticker
+``rh_get_stock_historicals``                      OHLC bars
+``rh_build_holdings``                             Full portfolio summary
+``rh_get_open_option_positions``                  Open option positions
+``rh_find_tradable_options``                      Search the option chain
+``rh_get_crypto_quote``                           Crypto quote
+``rh_order_buy_market`` *(write)*                 Market buy
+``rh_order_buy_limit`` *(write)*                  Limit buy
+``rh_cancel_stock_order`` *(write)*               Cancel a specific stock order
+``tda_get_accounts``                              List TDA accounts
+``tda_get_price_history``                         Historical bars from TDA
+``tda_get_option_chains``                         TDA option chain
+``tda_place_order`` *(write)*                     Place a TDA order
+``gem_get_pubticker``                             Gemini public ticker
+``gem_check_available_balances``                  Gemini account balances
+``gem_order`` / ``gem_order_market`` *(write)*    Place a Gemini order
+================================================  ===============================================
+
+Tools marked *(write)* are blocked when ``ROBIN_STOCKS_MCP_READ_ONLY=true``.
+
+Architecture
+^^^^^^^^^^^^
+
+::
+
+    robin_stocks_mcp/
+      app.py            shared FastMCP instance
+      server.py         CLI / startup
+      config.py         env-driven config
+      runtime.py        @safe_tool decorator, read-only guard, thread offload
+      auth.py           startup login bootstrap
+      tools/
+        robinhood_*.py  9 modules
+        tda_*.py        5 modules
+        gemini_*.py     4 modules
+
+Each tool is a thin async wrapper. ``@safe_tool`` blocks writes in read-only
+mode, catches exceptions, and awaits the wrapped coroutine. ``to_thread``
+runs the blocking ``requests``-based SDK call off the event loop.
+
+Testing
+^^^^^^^
+
+::
+
+    pip install -e ".[mcp,dev]"
+    pytest tests/mcp -q
+
+73 tests cover the runtime helpers, env-var parsing, the auth bootstrap, every
+tool module (registration + dispatch + write-guard + exception capture via
+``unittest.mock``), and a subprocess that boots the real server over STDIO,
+completes the MCP handshake, lists tools, and verifies the write guard.
+
+Safety notes
+^^^^^^^^^^^^
+
+- Read-only is the default for a reason. Confirm a tool's behaviour on
+  paper-money / sandbox first if your broker supports it
+  (``GEMINI_SANDBOX=true``).
+- Sessions are persisted via pickle under ``~/.tokens/`` by default. Treat
+  that directory like credentials.
+- The MCP server speaks plaintext JSON-RPC over STDIO. Do not run it across a
+  network without a transport you trust.
 
 .. _Robinhood Documentation: Robinhood.rst
 .. _Gemini Documentation: gemini.rst

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,8 @@
 env_files =
     .env
     .test.env
+testpaths =
+    tests
+asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning

--- a/robin_stocks_mcp/__init__.py
+++ b/robin_stocks_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""MCP server exposing the robin_stocks SDK as Model Context Protocol tools."""
+
+__version__ = "0.1.0"

--- a/robin_stocks_mcp/app.py
+++ b/robin_stocks_mcp/app.py
@@ -1,0 +1,20 @@
+"""Shared FastMCP instance imported by every tool module.
+
+Kept separate from `server.py` so tool modules can `from .app import mcp`
+without triggering CLI / argparse setup at import time.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(
+    "robin-stocks",
+    instructions=(
+        "Tools for interacting with Robinhood (`rh_*`), TD Ameritrade (`tda_*`), and Gemini "
+        "(`gem_*`) via the robin_stocks Python SDK. Read-only by default; set "
+        "ROBIN_STOCKS_MCP_READ_ONLY=false to enable order placement and other write tools. "
+        "Call `rh_login` / `tda_login` / `gem_login` first if credentials were not provided via "
+        "environment variables at startup."
+    ),
+)

--- a/robin_stocks_mcp/auth.py
+++ b/robin_stocks_mcp/auth.py
@@ -1,0 +1,162 @@
+"""Startup login bootstrap.
+
+Design: lean on the credential persistence each broker SDK already ships with.
+
+- **Robinhood** stores a session pickle at ``~/.tokens/robinhood.pickle`` after the
+  first interactive login. We reuse it directly — no creds required at startup.
+  If the pickle is missing or expired, we surface a clear message instead of
+  prompting (which would block STDIO).
+- **TD Ameritrade** stores credentials encrypted with a passcode. We just need
+  the passcode to unlock them; pass it via ``TDA_ENCRYPTION_PASSCODE`` or call
+  the ``tda_login`` MCP tool.
+- **Gemini** has no SDK-level persistence (just module globals). API keys must
+  come from env or the ``gem_login`` MCP tool.
+
+Env-var-supplied credentials remain a supported fallback for non-interactive
+deployments (CI, containers), but they are not the default path.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import sys
+from typing import Optional
+
+import robin_stocks.gemini as gem
+import robin_stocks.robinhood as rh
+import robin_stocks.tda as tda
+from robin_stocks.robinhood.helper import (
+    request_get,
+    set_login_state,
+    update_session,
+)
+from robin_stocks.robinhood.urls import positions_url
+
+from .config import Config
+
+
+def _log(msg: str) -> None:
+    print(f"[robin_stocks_mcp] {msg}", file=sys.stderr)
+
+
+def _resolve_mfa(value: Optional[str]) -> Optional[str]:
+    """Treat the env value as either a literal MFA code or a TOTP secret."""
+    if not value:
+        return None
+    if len(value) > 8 and all(c.isalnum() for c in value):
+        try:
+            import pyotp
+
+            return pyotp.TOTP(value).now()
+        except Exception:
+            pass
+    return value
+
+
+def _robinhood_pickle_path(cfg: Config) -> str:
+    base = cfg.rh_pickle_path or os.path.join(os.path.expanduser("~"), ".tokens")
+    name = cfg.rh_pickle_name or ""
+    return os.path.join(base, f"robinhood{name}.pickle")
+
+
+def try_reuse_robinhood_session(cfg: Config) -> bool:
+    """Load the persisted Robinhood session pickle without falling back to ``input()``.
+
+    Returns True iff the cached token is present and the server accepts it.
+    """
+    pickle_path = _robinhood_pickle_path(cfg)
+    if not os.path.isfile(pickle_path):
+        return False
+    try:
+        with open(pickle_path, "rb") as f:
+            data = pickle.load(f)
+        token_type = data["token_type"]
+        access_token = data["access_token"]
+        update_session("Authorization", f"{token_type} {access_token}")
+        # Probe the API — a 200 here means the cached token still works.
+        res = request_get(
+            positions_url(), "pagination", {"nonzero": "true"}, jsonify_data=False
+        )
+        res.raise_for_status()
+        set_login_state(True)
+        return True
+    except Exception as e:  # noqa: BLE001
+        set_login_state(False)
+        update_session("Authorization", None)
+        _log(f"Robinhood cached session not usable ({e!s}); ignoring.")
+        return False
+
+
+def bootstrap_login(cfg: Config) -> None:
+    """Attempt zero-prompt login for every broker.
+
+    Order of preference for each broker:
+      1. Re-use SDK-persisted credentials if available.
+      2. Fall back to env-supplied credentials.
+      3. Otherwise, leave unauthenticated and tell the user to log in interactively.
+    """
+    if not cfg.auto_login:
+        _log("auto-login disabled; skipping.")
+        return
+
+    # ---- Robinhood ----------------------------------------------------------
+    try:
+        rh_session_reused = try_reuse_robinhood_session(cfg)
+    except Exception as e:  # noqa: BLE001 - defense in depth
+        _log(f"Robinhood pickle-reuse threw unexpectedly ({e!s}); ignoring.")
+        rh_session_reused = False
+    if rh_session_reused:
+        _log("Robinhood: reusing persisted session from "
+             f"{_robinhood_pickle_path(cfg)}.")
+    elif cfg.rh_username and cfg.rh_password:
+        try:
+            rh.login(
+                username=cfg.rh_username,
+                password=cfg.rh_password,
+                mfa_code=_resolve_mfa(cfg.rh_mfa_code),
+                store_session=True,
+                pickle_path=cfg.rh_pickle_path or "",
+                pickle_name=cfg.rh_pickle_name or "",
+            )
+            _log("Robinhood: logged in with env-supplied credentials; "
+                 "session pickled for next time.")
+        except Exception as e:  # noqa: BLE001
+            _log(f"Robinhood env-credential login failed: {e}")
+    else:
+        _log(
+            "Robinhood: no cached session and no env credentials. "
+            "Run `robin-stocks-mcp login` once to seed the pickle, "
+            "or call the `rh_login` MCP tool with username/password/mfa_code."
+        )
+
+    # ---- TD Ameritrade ------------------------------------------------------
+    # TDA persists encrypted credentials; we still need the passcode to unlock.
+    if cfg.tda_encryption_passcode:
+        try:
+            tda.login(cfg.tda_encryption_passcode)
+            _log("TDA: logged in via encrypted credential store.")
+        except Exception as e:  # noqa: BLE001
+            _log(f"TDA login failed: {e}")
+    else:
+        _log(
+            "TDA: no encryption passcode set. Run "
+            "`robin-stocks-mcp tda-setup` once to seed encrypted credentials, "
+            "or set TDA_ENCRYPTION_PASSCODE."
+        )
+
+    # ---- Gemini -------------------------------------------------------------
+    # Gemini has no SDK-level persistence — API keys are required at runtime.
+    if cfg.gemini_api_key and cfg.gemini_secret_key:
+        try:
+            if cfg.gemini_sandbox:
+                gem.use_sand_box_urls(True)
+            gem.login(cfg.gemini_api_key, cfg.gemini_secret_key)
+            _log("Gemini: logged in with env-supplied API keys.")
+        except Exception as e:  # noqa: BLE001
+            _log(f"Gemini login failed: {e}")
+    else:
+        _log(
+            "Gemini: no API keys set. Either set GEMINI_API_KEY/GEMINI_SECRET_KEY "
+            "or call the `gem_login` MCP tool."
+        )

--- a/robin_stocks_mcp/config.py
+++ b/robin_stocks_mcp/config.py
@@ -1,0 +1,59 @@
+"""Environment-driven configuration for the robin_stocks MCP server."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except Exception:
+    pass
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+@dataclass(frozen=True)
+class Config:
+    # Global behaviour
+    read_only: bool = True  # Default safe: refuse order/transfer/cancel tools
+    auto_login: bool = True
+
+    # Robinhood
+    rh_username: Optional[str] = None
+    rh_password: Optional[str] = None
+    rh_mfa_code: Optional[str] = None  # TOTP secret OR static code
+    rh_pickle_path: Optional[str] = None
+    rh_pickle_name: Optional[str] = None
+
+    # TD Ameritrade
+    tda_encryption_passcode: Optional[str] = None
+
+    # Gemini
+    gemini_api_key: Optional[str] = None
+    gemini_secret_key: Optional[str] = None
+    gemini_sandbox: bool = False
+
+
+def load_config() -> Config:
+    return Config(
+        read_only=_bool_env("ROBIN_STOCKS_MCP_READ_ONLY", default=True),
+        auto_login=_bool_env("ROBIN_STOCKS_MCP_AUTO_LOGIN", default=True),
+        rh_username=os.getenv("ROBINHOOD_USERNAME") or os.getenv("RH_USERNAME"),
+        rh_password=os.getenv("ROBINHOOD_PASSWORD") or os.getenv("RH_PASSWORD"),
+        rh_mfa_code=os.getenv("ROBINHOOD_MFA_CODE") or os.getenv("RH_MFA_CODE"),
+        rh_pickle_path=os.getenv("ROBINHOOD_PICKLE_PATH"),
+        rh_pickle_name=os.getenv("ROBINHOOD_PICKLE_NAME"),
+        tda_encryption_passcode=os.getenv("TDA_ENCRYPTION_PASSCODE"),
+        gemini_api_key=os.getenv("GEMINI_API_KEY"),
+        gemini_secret_key=os.getenv("GEMINI_SECRET_KEY"),
+        gemini_sandbox=_bool_env("GEMINI_SANDBOX", default=False),
+    )

--- a/robin_stocks_mcp/runtime.py
+++ b/robin_stocks_mcp/runtime.py
@@ -1,0 +1,79 @@
+"""Runtime helpers: thread offload, error formatting, read-only guard."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+from typing import Any, Awaitable, Callable, TypeVar
+
+from .config import Config, load_config
+
+T = TypeVar("T")
+
+# Module-level singletons
+_config: Config = load_config()
+
+
+def get_config() -> Config:
+    return _config
+
+
+def set_config(cfg: Config) -> None:
+    global _config
+    _config = cfg
+
+
+class ReadOnlyError(RuntimeError):
+    """Raised when a write-operation tool is invoked while the server is in read-only mode."""
+
+
+def require_writes_allowed(tool_name: str) -> None:
+    """Block destructive tools when read-only mode is on."""
+    if _config.read_only:
+        raise ReadOnlyError(
+            f"Tool '{tool_name}' performs a write/trade/transfer action and is blocked because "
+            "ROBIN_STOCKS_MCP_READ_ONLY=true (default). Set ROBIN_STOCKS_MCP_READ_ONLY=false to enable."
+        )
+
+
+async def to_thread(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Run blocking SDK calls off the event loop."""
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def format_error(exc: BaseException) -> dict[str, Any]:
+    """Render an exception as a JSON-friendly object."""
+    return {
+        "error": True,
+        "type": type(exc).__name__,
+        "message": str(exc),
+    }
+
+
+def safe_tool(write: bool = False) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator: catch exceptions and (optionally) enforce read-only mode.
+
+    Tools decorated with `write=True` will be blocked when the server runs in read-only mode.
+    Any uncaught exception is converted into a structured error payload so the client can
+    surface the failure to the model without crashing the MCP transport.
+    """
+
+    def decorator(fn: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                if write:
+                    require_writes_allowed(fn.__name__)
+                result = fn(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            except ReadOnlyError as e:
+                return format_error(e)
+            except Exception as e:  # noqa: BLE001 - tool surface boundary
+                return format_error(e)
+
+        return wrapper
+
+    return decorator

--- a/robin_stocks_mcp/server.py
+++ b/robin_stocks_mcp/server.py
@@ -1,0 +1,163 @@
+"""Entry point for the robin_stocks MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+
+import robin_stocks.gemini as gem
+import robin_stocks.robinhood as rh
+import robin_stocks.tda as tda
+
+from .app import mcp
+from .auth import bootstrap_login
+from .config import load_config
+from .runtime import set_config
+
+
+def _register_all_tools() -> None:
+    # Importing each module registers its tools on the shared `mcp` instance.
+    from .tools import (  # noqa: F401
+        robinhood_auth,
+        robinhood_account,
+        robinhood_profiles,
+        robinhood_stocks,
+        robinhood_options,
+        robinhood_crypto,
+        robinhood_markets,
+        robinhood_orders,
+        robinhood_export,
+        tda_auth,
+        tda_account,
+        tda_stocks,
+        tda_markets,
+        tda_orders,
+        gemini_auth,
+        gemini_account,
+        gemini_crypto,
+        gemini_orders,
+    )
+
+
+def _cmd_serve(args: argparse.Namespace) -> int:
+    cfg = load_config()
+    set_config(cfg)
+    bootstrap_login(cfg)
+    _register_all_tools()
+    print(
+        f"[robin_stocks_mcp] starting; transport={args.transport} "
+        f"read_only={cfg.read_only} auto_login={cfg.auto_login}",
+        file=sys.stderr,
+    )
+    mcp.run(transport=args.transport)
+    return 0
+
+
+def _cmd_login(args: argparse.Namespace) -> int:
+    """Interactive Robinhood first-time login. Writes the session pickle to disk."""
+    print("Robinhood interactive login. Credentials are not stored in plaintext —")
+    print("only the resulting session token is pickled under ~/.tokens/.")
+    username = args.username or input("Robinhood username: ").strip()
+    password = args.password or getpass.getpass("Robinhood password: ")
+    mfa = args.mfa_code  # may be None; the SDK will prompt during login if needed
+    rh.login(username=username, password=password, mfa_code=mfa, store_session=True)
+    print("Login complete; pickle written. Future `robin-stocks-mcp` runs will reuse it.")
+    return 0
+
+
+def _cmd_tda_setup(args: argparse.Namespace) -> int:
+    """One-time TDA credential seeding. Stores encrypted tokens via the SDK."""
+    print("TD Ameritrade first-time setup. You'll need a TDA developer-portal")
+    print("client_id, an authorization_token, and a refresh_token.")
+    if args.generate_passcode:
+        passcode = tda.generate_encryption_passcode()
+        print(f"\nGenerated encryption passcode (save this — you'll need it on every run):")
+        print(f"  {passcode}\n")
+    else:
+        passcode = args.passcode or getpass.getpass("Encryption passcode: ")
+    client_id = args.client_id or input("client_id: ").strip()
+    auth_token = args.auth_token or getpass.getpass("authorization_token: ")
+    refresh = args.refresh_token or getpass.getpass("refresh_token: ")
+    tda.login_first_time(passcode, client_id, auth_token, refresh)
+    print("TDA encrypted credentials saved. Set TDA_ENCRYPTION_PASSCODE in your")
+    print("environment (or pass it via the tda_login MCP tool) to unlock them.")
+    return 0
+
+
+def _cmd_logout(args: argparse.Namespace) -> int:
+    """Clear cached Robinhood / Gemini sessions."""
+    if args.broker in ("rh", "all"):
+        try:
+            rh.logout()
+            print("Robinhood: cleared session.")
+        except Exception as e:  # noqa: BLE001
+            print(f"Robinhood logout error: {e}", file=sys.stderr)
+    if args.broker in ("gem", "all"):
+        try:
+            gem.logout()
+            print("Gemini: cleared session.")
+        except Exception as e:  # noqa: BLE001
+            print(f"Gemini logout error: {e}", file=sys.stderr)
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="robin-stocks-mcp")
+    sub = parser.add_subparsers(dest="command")
+
+    serve = sub.add_parser("serve", help="Run the MCP server (default).")
+    serve.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "streamable-http"],
+        default="stdio",
+    )
+    serve.set_defaults(func=_cmd_serve)
+
+    login_p = sub.add_parser(
+        "login", help="Interactive first-time Robinhood login (seeds the pickle)."
+    )
+    login_p.add_argument("--username")
+    login_p.add_argument("--password")
+    login_p.add_argument("--mfa-code", dest="mfa_code")
+    login_p.set_defaults(func=_cmd_login)
+
+    tda_p = sub.add_parser("tda-setup", help="One-time TDA encrypted credential setup.")
+    tda_p.add_argument("--generate-passcode", action="store_true",
+                       help="Generate a fresh encryption passcode and print it.")
+    tda_p.add_argument("--passcode")
+    tda_p.add_argument("--client-id", dest="client_id")
+    tda_p.add_argument("--auth-token", dest="auth_token")
+    tda_p.add_argument("--refresh-token", dest="refresh_token")
+    tda_p.set_defaults(func=_cmd_tda_setup)
+
+    logout_p = sub.add_parser("logout", help="Clear cached broker sessions.")
+    logout_p.add_argument("broker", choices=["rh", "gem", "all"], default="all", nargs="?")
+    logout_p.set_defaults(func=_cmd_logout)
+
+    # Top-level `--transport` flag for backwards-compatible `robin-stocks-mcp --transport stdio`
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "streamable-http"],
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        # Default to `serve`, optionally honoring the legacy top-level --transport flag.
+        args.command = "serve"
+        args.func = _cmd_serve
+        if getattr(args, "transport", None) is None:
+            args.transport = "stdio"
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/robin_stocks_mcp/tools/__init__.py
+++ b/robin_stocks_mcp/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tool modules. Importing any of these registers tools on the shared `mcp` instance."""

--- a/robin_stocks_mcp/tools/gemini_account.py
+++ b/robin_stocks_mcp/tools/gemini_account.py
@@ -1,0 +1,69 @@
+"""Gemini account tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.gemini as gem
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_account_detail(jsonify: Optional[bool] = None) -> Any:
+    """Information about the profile attached to the Gemini API key."""
+    return await to_thread(gem.get_account_detail, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_check_available_balances(jsonify: Optional[bool] = None) -> Any:
+    """Available balances per currency."""
+    return await to_thread(gem.check_available_balances, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_check_notional_balances(jsonify: Optional[bool] = None) -> Any:
+    """Notional (USD) balances per currency."""
+    return await to_thread(gem.check_notional_balances, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_check_transfers(
+    timestamp: Optional[str] = None,
+    limit_transfers: int = 10,
+    show_completed_deposit_advances: bool = False,
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """List transfer history on Gemini."""
+    return await to_thread(
+        gem.check_transfers,
+        timestamp=timestamp,
+        limit_transfers=limit_transfers,
+        show_completed_deposit_advances=show_completed_deposit_advances,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_deposit_addresses(
+    network: str, timestamp: Optional[str] = None, jsonify: Optional[bool] = None
+) -> Any:
+    """Get deposit addresses for a given network (e.g. 'bitcoin', 'ethereum')."""
+    return await to_thread(
+        gem.get_deposit_addresses, network, timestamp=timestamp, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def gem_withdraw_crypto_funds(
+    address: str, amount: float, currency: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Withdraw crypto from Gemini to a destination address."""
+    return await to_thread(gem.withdraw_crypto_funds, address, amount, currency, jsonify=jsonify)

--- a/robin_stocks_mcp/tools/gemini_auth.py
+++ b/robin_stocks_mcp/tools/gemini_auth.py
@@ -1,0 +1,41 @@
+"""Gemini authentication tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.gemini as gem
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_login(api_key: str, secret_key: str) -> str:
+    """Authenticate with Gemini using an API key + secret pair."""
+    await to_thread(gem.login, api_key, secret_key)
+    return "ok: Gemini login complete"
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_logout() -> str:
+    """Remove the Gemini API/secret key from the session."""
+    await to_thread(gem.logout)
+    return "ok: logged out of Gemini"
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_heartbeat(jsonify: Optional[bool] = None) -> Any:
+    """Send a heartbeat to keep the Gemini session alive."""
+    return await to_thread(gem.heartbeat, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_use_sandbox(use_sandbox: bool) -> str:
+    """Switch between the Gemini live and sandbox API base URLs."""
+    await to_thread(gem.use_sand_box_urls, use_sandbox)
+    return f"ok: Gemini sandbox={'on' if use_sandbox else 'off'}"

--- a/robin_stocks_mcp/tools/gemini_crypto.py
+++ b/robin_stocks_mcp/tools/gemini_crypto.py
@@ -1,0 +1,59 @@
+"""Gemini crypto market-data tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.gemini as gem
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_pubticker(ticker: str, jsonify: Optional[bool] = None) -> Any:
+    """Public ticker info (bid/ask/last) for a Gemini symbol (e.g. 'btcusd')."""
+    return await to_thread(gem.get_pubticker, ticker, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_ticker(ticker: str, jsonify: Optional[bool] = None) -> Any:
+    """Recent trade info for a Gemini symbol."""
+    return await to_thread(gem.get_ticker, ticker, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_symbols(jsonify: Optional[bool] = None) -> Any:
+    """All tradable Gemini symbols."""
+    return await to_thread(gem.get_symbols, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_symbol_details(ticker: str, jsonify: Optional[bool] = None) -> Any:
+    """Detailed info about a single Gemini symbol."""
+    return await to_thread(gem.get_symbol_details, ticker, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_price(ticker: str, jsonify: Optional[bool] = None) -> Any:
+    """Current price for a Gemini symbol."""
+    return await to_thread(gem.get_price, ticker, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_notional_volume(jsonify: Optional[bool] = None) -> Any:
+    """Account notional volume info."""
+    return await to_thread(gem.get_notional_volume, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_trade_volume(jsonify: Optional[bool] = None) -> Any:
+    """Account trade volume info."""
+    return await to_thread(gem.get_trade_volume, jsonify=jsonify)

--- a/robin_stocks_mcp/tools/gemini_orders.py
+++ b/robin_stocks_mcp/tools/gemini_orders.py
@@ -1,0 +1,96 @@
+"""Gemini order tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.gemini as gem
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_get_trades_for_crypto(
+    ticker: str,
+    limit_trades: int = 50,
+    timestamp: Optional[str] = None,
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """Trade history for a Gemini symbol."""
+    return await to_thread(
+        gem.get_trades_for_crypto,
+        ticker,
+        limit_trades=limit_trades,
+        timestamp=timestamp,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_active_orders(jsonify: Optional[bool] = None) -> Any:
+    """All active Gemini orders."""
+    return await to_thread(gem.active_orders, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def gem_order_status(order_id: str, jsonify: Optional[bool] = None) -> Any:
+    """Status of a specific Gemini order."""
+    return await to_thread(gem.order_status, order_id, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def gem_cancel_order(order_id: str, jsonify: Optional[bool] = None) -> Any:
+    """Cancel a specific Gemini order."""
+    return await to_thread(gem.cancel_order, order_id, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def gem_cancel_all_session_orders(jsonify: Optional[bool] = None) -> Any:
+    """Cancel all orders opened by the current Gemini session."""
+    return await to_thread(gem.cancel_all_session_orders, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def gem_cancel_all_active_orders(jsonify: Optional[bool] = None) -> Any:
+    """Cancel all Gemini orders for the account."""
+    return await to_thread(gem.cancel_all_active_orders, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def gem_order(
+    symbol: str,
+    side: str,
+    quantity: float,
+    price: Optional[float] = None,
+    order_type: str = "exchange limit",
+    options: Optional[list] = None,
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """Submit a Gemini order. side: 'buy'/'sell'. order_type defaults to 'exchange limit'."""
+    return await to_thread(
+        gem.order,
+        symbol,
+        side,
+        quantity,
+        price=price,
+        order_type=order_type,
+        options=options,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def gem_order_market(
+    symbol: str, side: str, quantity: float, jsonify: Optional[bool] = None
+) -> Any:
+    """Submit a market order on Gemini."""
+    return await to_thread(gem.order_market, symbol, side, quantity, jsonify=jsonify)

--- a/robin_stocks_mcp/tools/robinhood_account.py
+++ b/robin_stocks_mcp/tools/robinhood_account.py
@@ -1,0 +1,275 @@
+"""Robinhood account tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_phoenix_account(info: Optional[str] = None) -> Any:
+    """Return unified information about your Robinhood account (cash, equity, buying power)."""
+    return await to_thread(rh.load_phoenix_account, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_historical_portfolio(
+    interval: Optional[str] = None,
+    span: str = "week",
+    bounds: str = "regular",
+    info: Optional[str] = None,
+) -> Any:
+    """Get historical portfolio value over time.
+
+    interval: one of 5minute / 10minute / hour / day / week
+    span:     one of day / week / month / 3month / year / 5year / all
+    bounds:   regular / extended / trading / 24_7
+    """
+    return await to_thread(
+        rh.get_historical_portfolio, interval=interval, span=span, bounds=bounds, info=info
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_positions(info: Optional[str] = None) -> Any:
+    """Return a list containing every position ever traded."""
+    return await to_thread(rh.get_all_positions, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_open_stock_positions(
+    account_number: Optional[str] = None, info: Optional[str] = None
+) -> Any:
+    """Return a list of stocks that are currently held."""
+    return await to_thread(rh.get_open_stock_positions, account_number=account_number, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_dividends(info: Optional[str] = None) -> Any:
+    """Return a list of dividend transactions with rate, amount, shares, and date paid."""
+    return await to_thread(rh.get_dividends, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_total_dividends() -> Any:
+    """Return the total amount of dividends paid to the account."""
+    return await to_thread(rh.get_total_dividends)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_dividends_by_instrument(instrument: str, dividend_data: list) -> Any:
+    """Given an instrument URL and the result of rh_get_dividends, summarize that instrument's dividends."""
+    return await to_thread(rh.get_dividends_by_instrument, instrument, dividend_data)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_notifications(info: Optional[str] = None) -> Any:
+    """Return a list of account notifications."""
+    return await to_thread(rh.get_notifications, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_latest_notification() -> Any:
+    """Return the time of the latest notification."""
+    return await to_thread(rh.get_latest_notification)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_wire_transfers(info: Optional[str] = None) -> Any:
+    """Return a list of wire transfers."""
+    return await to_thread(rh.get_wire_transfers, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_margin_calls(symbol: Optional[str] = None) -> Any:
+    """Return all margin calls (or those for a specific stock)."""
+    return await to_thread(rh.get_margin_calls, symbol=symbol)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_withdrawl_funds_to_bank_account(
+    ach_relationship: str, amount: float, info: Optional[str] = None
+) -> Any:
+    """Withdraw money from Robinhood to a linked bank account."""
+    return await to_thread(rh.withdrawl_funds_to_bank_account, ach_relationship, amount, info=info)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_deposit_funds_to_robinhood_account(
+    ach_relationship: str, amount: float, info: Optional[str] = None
+) -> Any:
+    """Deposit money from a linked bank account to Robinhood."""
+    return await to_thread(
+        rh.deposit_funds_to_robinhood_account, ach_relationship, amount, info=info
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_linked_bank_accounts(info: Optional[str] = None) -> Any:
+    """Return all linked bank accounts."""
+    return await to_thread(rh.get_linked_bank_accounts, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_bank_account_info(id: str, info: Optional[str] = None) -> Any:
+    """Return info for a single linked bank account by id."""
+    return await to_thread(rh.get_bank_account_info, id, info=info)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_unlink_bank_account(id: str) -> Any:
+    """Unlink a bank account by id."""
+    return await to_thread(rh.unlink_bank_account, id)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_bank_transfers(
+    direction: Optional[str] = None, info: Optional[str] = None
+) -> Any:
+    """Return all bank transfers made for the account. `direction` filters deposit/withdraw."""
+    return await to_thread(rh.get_bank_transfers, direction=direction, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_card_transactions(
+    cardType: Optional[str] = None, info: Optional[str] = None
+) -> Any:
+    """Return all debit card transactions made on the account."""
+    return await to_thread(rh.get_card_transactions, cardType=cardType, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_stock_loan_payments(info: Optional[str] = None) -> Any:
+    """Return a list of stock loan payments."""
+    return await to_thread(rh.get_stock_loan_payments, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_interest_payments(info: Optional[str] = None) -> Any:
+    """Return a list of interest payments."""
+    return await to_thread(rh.get_interest_payments, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_margin_interest(info: Optional[str] = None) -> Any:
+    """Return a list of margin interest charges."""
+    return await to_thread(rh.get_margin_interest, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_subscription_fees(info: Optional[str] = None) -> Any:
+    """Return a list of Robinhood Gold subscription fees."""
+    return await to_thread(rh.get_subscription_fees, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_referrals(info: Optional[str] = None) -> Any:
+    """Return a list of referrals."""
+    return await to_thread(rh.get_referrals, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_day_trades(info: Optional[str] = None) -> Any:
+    """Return recent day trades."""
+    return await to_thread(rh.get_day_trades, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_documents(info: Optional[str] = None) -> Any:
+    """Return a list of documents released to the account."""
+    return await to_thread(rh.get_documents, info=info)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_download_document(url: str, name: Optional[str] = None, dirpath: Optional[str] = None) -> str:
+    """Download a single document by URL and save it as a PDF on disk."""
+    await to_thread(rh.download_document, url, name=name, dirpath=dirpath)
+    return f"ok: document saved (name={name!r}, dirpath={dirpath!r})"
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_download_all_documents(
+    doctype: Optional[str] = None, dirpath: Optional[str] = None
+) -> str:
+    """Download all documents associated with the account as PDFs."""
+    await to_thread(rh.download_all_documents, doctype=doctype, dirpath=dirpath)
+    return f"ok: documents saved (doctype={doctype!r}, dirpath={dirpath!r})"
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_watchlists(info: Optional[str] = None) -> Any:
+    """Return a list of all watchlists that have been created."""
+    return await to_thread(rh.get_all_watchlists, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_watchlist_by_name(
+    name: str = "My First List", info: Optional[str] = None
+) -> Any:
+    """Return the stocks in a single watchlist."""
+    return await to_thread(rh.get_watchlist_by_name, name=name, info=info)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_post_symbols_to_watchlist(
+    inputSymbols: list[str], name: str = "My First List"
+) -> Any:
+    """Add stock tickers to a watchlist."""
+    return await to_thread(rh.post_symbols_to_watchlist, inputSymbols, name=name)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_delete_symbols_from_watchlist(
+    inputSymbols: list[str], name: str = "My First List"
+) -> Any:
+    """Delete stock tickers from a watchlist."""
+    return await to_thread(rh.delete_symbols_from_watchlist, inputSymbols, name=name)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_build_holdings(with_dividends: bool = False) -> Any:
+    """Build a dictionary of important info regarding the stocks/positions the user owns."""
+    return await to_thread(rh.build_holdings, with_dividends=with_dividends)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_build_user_profile(account_number: Optional[str] = None) -> Any:
+    """Build a dictionary summarizing the user account (cash, equity, dividends)."""
+    return await to_thread(rh.build_user_profile, account_number=account_number)

--- a/robin_stocks_mcp/tools/robinhood_auth.py
+++ b/robin_stocks_mcp/tools/robinhood_auth.py
@@ -1,0 +1,49 @@
+"""Robinhood authentication tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_login(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    expiresIn: int = 86400,
+    scope: str = "internal",
+    store_session: bool = True,
+    mfa_code: Optional[str] = None,
+    pickle_path: str = "",
+    pickle_name: str = "",
+) -> Any:
+    """Log in to Robinhood. Handles MFA, session persistence, and verification workflows.
+
+    If `mfa_code` is a base32 TOTP secret, pass the *current* code instead — this tool does not
+    expand TOTP secrets (env-var auto-login does). Pickle credentials are written under
+    ~/.tokens by default.
+    """
+    return await to_thread(
+        rh.login,
+        username=username,
+        password=password,
+        expiresIn=expiresIn,
+        scope=scope,
+        store_session=store_session,
+        mfa_code=mfa_code,
+        pickle_path=pickle_path,
+        pickle_name=pickle_name,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_logout() -> str:
+    """Log out of Robinhood by clearing session data."""
+    await to_thread(rh.logout)
+    return "ok: logged out of Robinhood"

--- a/robin_stocks_mcp/tools/robinhood_crypto.py
+++ b/robin_stocks_mcp/tools/robinhood_crypto.py
@@ -1,0 +1,67 @@
+"""Robinhood crypto data tools (read-only)."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_crypto_profile(info: Optional[str] = None) -> Any:
+    """Information associated with the crypto account."""
+    return await to_thread(rh.load_crypto_profile, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_positions(info: Optional[str] = None) -> Any:
+    """Crypto positions for the account."""
+    return await to_thread(rh.get_crypto_positions, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_currency_pairs(info: Optional[str] = None) -> Any:
+    """All crypto currency pairs available for trading."""
+    return await to_thread(rh.get_crypto_currency_pairs, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_info(symbol: str, info: Optional[str] = None) -> Any:
+    """Info for a specific crypto symbol."""
+    return await to_thread(rh.get_crypto_info, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_quote(symbol: str, info: Optional[str] = None) -> Any:
+    """Crypto quote: low/high/open price."""
+    return await to_thread(rh.get_crypto_quote, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_quote_from_id(id: str, info: Optional[str] = None) -> Any:
+    """Crypto quote by Robinhood crypto id (instead of ticker)."""
+    return await to_thread(rh.get_crypto_quote_from_id, id, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_historicals(
+    symbol: str,
+    interval: str = "hour",
+    span: str = "week",
+    bounds: str = "24_7",
+    info: Optional[str] = None,
+) -> Any:
+    """Historical OHLC data for a crypto symbol."""
+    return await to_thread(
+        rh.get_crypto_historicals, symbol, interval=interval, span=span, bounds=bounds, info=info
+    )

--- a/robin_stocks_mcp/tools/robinhood_export.py
+++ b/robin_stocks_mcp/tools/robinhood_export.py
@@ -1,0 +1,42 @@
+"""Robinhood CSV export tools (write to disk)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_export_completed_stock_orders(
+    dir_path: str, file_name: Optional[str] = None, account_number: Optional[str] = None
+) -> str:
+    """Write all completed stock orders to a CSV in dir_path."""
+    await to_thread(
+        rh.export_completed_stock_orders, dir_path, file_name=file_name, account_number=account_number
+    )
+    return f"ok: stock orders exported to {dir_path}"
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_export_completed_crypto_orders(
+    dir_path: str, file_name: Optional[str] = None
+) -> str:
+    """Write all completed crypto orders to a CSV in dir_path."""
+    await to_thread(rh.export_completed_crypto_orders, dir_path, file_name=file_name)
+    return f"ok: crypto orders exported to {dir_path}"
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_export_completed_option_orders(
+    dir_path: str, file_name: Optional[str] = None
+) -> str:
+    """Write all completed option orders to a CSV in dir_path."""
+    await to_thread(rh.export_completed_option_orders, dir_path, file_name=file_name)
+    return f"ok: option orders exported to {dir_path}"

--- a/robin_stocks_mcp/tools/robinhood_markets.py
+++ b/robin_stocks_mcp/tools/robinhood_markets.py
@@ -1,0 +1,82 @@
+"""Robinhood market data tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_top_movers_sp500(direction: str, info: Optional[str] = None) -> Any:
+    """Top S&P500 movers for the day. direction: 'up' or 'down'."""
+    return await to_thread(rh.get_top_movers_sp500, direction, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_top_100(info: Optional[str] = None) -> Any:
+    """Top 100 stocks on Robinhood."""
+    return await to_thread(rh.get_top_100, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_top_movers(info: Optional[str] = None) -> Any:
+    """Top 20 movers on Robinhood."""
+    return await to_thread(rh.get_top_movers, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_stocks_from_market_tag(tag: str, info: Optional[str] = None) -> Any:
+    """Stocks matching a category tag (e.g. 'technology', 'finance')."""
+    return await to_thread(rh.get_all_stocks_from_market_tag, tag, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_markets(info: Optional[str] = None) -> Any:
+    """List of available markets."""
+    return await to_thread(rh.get_markets, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_market_today_hours(market: str, info: Optional[str] = None) -> Any:
+    """Today's open/close hours for a specific market."""
+    return await to_thread(rh.get_market_today_hours, market, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_market_next_open_hours(market: str, info: Optional[str] = None) -> Any:
+    """Next open day's hours for a specific market."""
+    return await to_thread(rh.get_market_next_open_hours, market, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_market_next_open_hours_after_date(
+    market: str, date: str, info: Optional[str] = None
+) -> Any:
+    """Next open day's hours after a given date (YYYY-MM-DD)."""
+    return await to_thread(rh.get_market_next_open_hours_after_date, market, date, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_market_hours(market: str, date: str, info: Optional[str] = None) -> Any:
+    """Open/close hours for a market on a specific date (YYYY-MM-DD)."""
+    return await to_thread(rh.get_market_hours, market, date, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_currency_pairs(info: Optional[str] = None) -> Any:
+    """Available currency pairs."""
+    return await to_thread(rh.get_currency_pairs, info=info)

--- a/robin_stocks_mcp/tools/robinhood_options.py
+++ b/robin_stocks_mcp/tools/robinhood_options.py
@@ -1,0 +1,246 @@
+"""Robinhood options tools."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Union
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+Symbols = Union[str, List[str]]
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_aggregate_positions(
+    info: Optional[str] = None, account_number: Optional[str] = None
+) -> Any:
+    """Collapse all option orders for each stock into a single dict per stock."""
+    return await to_thread(rh.get_aggregate_positions, info=info, account_number=account_number)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_aggregate_open_positions(
+    info: Optional[str] = None, account_number: Optional[str] = None
+) -> Any:
+    """Collapse all open option positions for each stock into a single dict per stock."""
+    return await to_thread(
+        rh.get_aggregate_open_positions, info=info, account_number=account_number
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_market_options(info: Optional[str] = None) -> Any:
+    """Return a list of all market option positions."""
+    return await to_thread(rh.get_market_options, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_option_positions(
+    info: Optional[str] = None, account_number: Optional[str] = None
+) -> Any:
+    """All option positions ever held for the account."""
+    return await to_thread(rh.get_all_option_positions, info=info, account_number=account_number)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_open_option_positions(
+    account_number: Optional[str] = None, info: Optional[str] = None
+) -> Any:
+    """All open option positions for the account."""
+    return await to_thread(rh.get_open_option_positions, account_number=account_number, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_chains(symbol: str, info: Optional[str] = None) -> Any:
+    """Option chain summary information for a ticker."""
+    return await to_thread(rh.get_chains, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_tradable_options(
+    symbol: str,
+    expirationDate: Optional[str] = None,
+    strikePrice: Optional[Union[float, str]] = None,
+    optionType: Optional[str] = None,
+    info: Optional[str] = None,
+) -> Any:
+    """List all tradable options for a stock, optionally filtered."""
+    return await to_thread(
+        rh.find_tradable_options,
+        symbol,
+        expirationDate=expirationDate,
+        strikePrice=strikePrice,
+        optionType=optionType,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_options_by_expiration(
+    inputSymbols: Symbols,
+    expirationDate: str,
+    optionType: Optional[str] = None,
+    info: Optional[str] = None,
+) -> Any:
+    """Option orders that match an expiration date for the given tickers."""
+    return await to_thread(
+        rh.find_options_by_expiration,
+        inputSymbols,
+        expirationDate,
+        optionType=optionType,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_options_by_strike(
+    inputSymbols: Symbols,
+    strikePrice: Union[float, str],
+    optionType: Optional[str] = None,
+    info: Optional[str] = None,
+) -> Any:
+    """Option orders that match a strike price for the given tickers."""
+    return await to_thread(
+        rh.find_options_by_strike,
+        inputSymbols,
+        strikePrice,
+        optionType=optionType,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_options_by_expiration_and_strike(
+    inputSymbols: Symbols,
+    expirationDate: str,
+    strikePrice: Union[float, str],
+    optionType: Optional[str] = None,
+    info: Optional[str] = None,
+) -> Any:
+    """Option orders matching both expiration and strike."""
+    return await to_thread(
+        rh.find_options_by_expiration_and_strike,
+        inputSymbols,
+        expirationDate,
+        strikePrice,
+        optionType=optionType,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_options_by_specific_profitability(
+    inputSymbols: Symbols,
+    expirationDate: Optional[str] = None,
+    strikePrice: Optional[Union[float, str]] = None,
+    optionType: Optional[str] = None,
+    typeProfit: str = "chance_of_profit_short",
+    profitFloor: float = 0.0,
+    profitCeiling: float = 1.0,
+    info: Optional[str] = None,
+) -> Any:
+    """Option market data for tickers within a profitability range."""
+    return await to_thread(
+        rh.find_options_by_specific_profitability,
+        inputSymbols,
+        expirationDate=expirationDate,
+        strikePrice=strikePrice,
+        optionType=optionType,
+        typeProfit=typeProfit,
+        profitFloor=profitFloor,
+        profitCeiling=profitCeiling,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_option_market_data_by_id(id: str, info: Optional[str] = None) -> Any:
+    """Option market data (greeks, OI, chance of profit, adjusted mark) by id."""
+    return await to_thread(rh.get_option_market_data_by_id, id, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_option_market_data(
+    inputSymbols: Symbols,
+    expirationDate: str,
+    strikePrice: Union[float, str],
+    optionType: str,
+    info: Optional[str] = None,
+) -> Any:
+    """Option market data (greeks, OI, chance of profit) for a specific contract."""
+    return await to_thread(
+        rh.get_option_market_data,
+        inputSymbols,
+        expirationDate,
+        strikePrice,
+        optionType,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_option_instrument_data_by_id(id: str, info: Optional[str] = None) -> Any:
+    """Option instrument data by id."""
+    return await to_thread(rh.get_option_instrument_data_by_id, id, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_option_instrument_data(
+    symbol: str,
+    expirationDate: str,
+    strikePrice: Union[float, str],
+    optionType: str,
+    info: Optional[str] = None,
+) -> Any:
+    """Option instrument data for a specific contract."""
+    return await to_thread(
+        rh.get_option_instrument_data,
+        symbol,
+        expirationDate,
+        strikePrice,
+        optionType,
+        info=info,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_option_historicals(
+    symbol: str,
+    expirationDate: str,
+    strikePrice: Union[float, str],
+    optionType: str,
+    interval: str = "hour",
+    span: str = "week",
+    bounds: str = "regular",
+    info: Optional[str] = None,
+) -> Any:
+    """Historical price data for an option contract."""
+    return await to_thread(
+        rh.get_option_historicals,
+        symbol,
+        expirationDate,
+        strikePrice,
+        optionType,
+        interval=interval,
+        span=span,
+        bounds=bounds,
+        info=info,
+    )

--- a/robin_stocks_mcp/tools/robinhood_orders.py
+++ b/robin_stocks_mcp/tools/robinhood_orders.py
@@ -1,0 +1,862 @@
+"""Robinhood order tools. Read tools are safe; placement/cancel are write-guarded."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+# ---------------------------------------------------------------------------
+# Read tools (history / info / find)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_stock_orders(
+    info: Optional[str] = None,
+    account_number: Optional[str] = None,
+    start_date: Optional[str] = None,
+) -> Any:
+    """All stock orders ever processed for the account."""
+    return await to_thread(
+        rh.get_all_stock_orders, info=info, account_number=account_number, start_date=start_date
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_option_orders(
+    info: Optional[str] = None,
+    account_number: Optional[str] = None,
+    start_date: Optional[str] = None,
+) -> Any:
+    """All option orders ever processed for the account."""
+    return await to_thread(
+        rh.get_all_option_orders, info=info, account_number=account_number, start_date=start_date
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_crypto_orders(info: Optional[str] = None) -> Any:
+    """All crypto orders ever processed for the account."""
+    return await to_thread(rh.get_all_crypto_orders, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_open_stock_orders(
+    info: Optional[str] = None, account_number: Optional[str] = None
+) -> Any:
+    """All currently-open stock orders."""
+    return await to_thread(rh.get_all_open_stock_orders, info=info, account_number=account_number)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_open_option_orders(
+    info: Optional[str] = None, account_number: Optional[str] = None
+) -> Any:
+    """All currently-open option orders."""
+    return await to_thread(rh.get_all_open_option_orders, info=info, account_number=account_number)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_all_open_crypto_orders(info: Optional[str] = None) -> Any:
+    """All currently-open crypto orders."""
+    return await to_thread(rh.get_all_open_crypto_orders, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_stock_order_info(orderID: str) -> Any:
+    """Info for a single stock order."""
+    return await to_thread(rh.get_stock_order_info, orderID)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_option_order_info(order_id: str) -> Any:
+    """Info for a single option order."""
+    return await to_thread(rh.get_option_order_info, order_id)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_crypto_order_info(order_id: str) -> Any:
+    """Info for a single crypto order."""
+    return await to_thread(rh.get_crypto_order_info, order_id)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_stock_orders(filters: dict) -> Any:
+    """Find stock orders matching keyword filters (e.g. {'state': 'filled', 'side': 'buy'})."""
+    return await to_thread(rh.find_stock_orders, **filters)
+
+
+# ---------------------------------------------------------------------------
+# Cancellation tools (write)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_cancel_stock_order(orderID: str) -> Any:
+    """Cancel a specific stock order."""
+    return await to_thread(rh.cancel_stock_order, orderID)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_cancel_option_order(orderID: str) -> Any:
+    """Cancel a specific option order."""
+    return await to_thread(rh.cancel_option_order, orderID)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_cancel_crypto_order(orderID: str) -> Any:
+    """Cancel a specific crypto order."""
+    return await to_thread(rh.cancel_crypto_order, orderID)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_cancel_all_stock_orders(account_number: Optional[str] = None) -> Any:
+    """Cancel ALL open stock orders."""
+    return await to_thread(rh.cancel_all_stock_orders, account_number=account_number)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_cancel_all_option_orders(account_number: Optional[str] = None) -> Any:
+    """Cancel ALL open option orders."""
+    return await to_thread(rh.cancel_all_option_orders, account_number=account_number)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_cancel_all_crypto_orders() -> Any:
+    """Cancel ALL open crypto orders."""
+    return await to_thread(rh.cancel_all_crypto_orders)
+
+
+# ---------------------------------------------------------------------------
+# Stock placement
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_market(
+    symbol: str,
+    quantity: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a market BUY order for whole shares."""
+    return await to_thread(
+        rh.order_buy_market,
+        symbol,
+        quantity,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_fractional_by_quantity(
+    symbol: str,
+    quantity: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gfd",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Buy fractional shares by quantity."""
+    return await to_thread(
+        rh.order_buy_fractional_by_quantity,
+        symbol,
+        quantity,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_fractional_by_price(
+    symbol: str,
+    amountInDollars: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gfd",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+    market_hours: str = "regular_hours",
+) -> Any:
+    """Buy fractional shares by dollar amount."""
+    return await to_thread(
+        rh.order_buy_fractional_by_price,
+        symbol,
+        amountInDollars,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+        market_hours=market_hours,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_limit(
+    symbol: str,
+    quantity: float,
+    limitPrice: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a limit BUY order."""
+    return await to_thread(
+        rh.order_buy_limit,
+        symbol,
+        quantity,
+        limitPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_stop_loss(
+    symbol: str,
+    quantity: float,
+    stopPrice: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a stop-loss BUY order (turns into a market order at stopPrice)."""
+    return await to_thread(
+        rh.order_buy_stop_loss,
+        symbol,
+        quantity,
+        stopPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_stop_limit(
+    symbol: str,
+    quantity: float,
+    limitPrice: float,
+    stopPrice: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a stop-limit BUY order."""
+    return await to_thread(
+        rh.order_buy_stop_limit,
+        symbol,
+        quantity,
+        limitPrice,
+        stopPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_trailing_stop(
+    symbol: str,
+    quantity: float,
+    trailAmount: float,
+    trailType: str = "percentage",
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a trailing-stop BUY order."""
+    return await to_thread(
+        rh.order_buy_trailing_stop,
+        symbol,
+        quantity,
+        trailAmount,
+        trailType=trailType,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_market(
+    symbol: str,
+    quantity: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a market SELL order for whole shares."""
+    return await to_thread(
+        rh.order_sell_market,
+        symbol,
+        quantity,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_fractional_by_quantity(
+    symbol: str,
+    quantity: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gfd",
+    priceType: str = "bid_price",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+    market_hours: str = "regular_hours",
+) -> Any:
+    """Sell fractional shares by quantity."""
+    return await to_thread(
+        rh.order_sell_fractional_by_quantity,
+        symbol,
+        quantity,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        priceType=priceType,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+        market_hours=market_hours,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_fractional_by_price(
+    symbol: str,
+    amountInDollars: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gfd",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Sell fractional shares by dollar amount."""
+    return await to_thread(
+        rh.order_sell_fractional_by_price,
+        symbol,
+        amountInDollars,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_limit(
+    symbol: str,
+    quantity: float,
+    limitPrice: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a limit SELL order."""
+    return await to_thread(
+        rh.order_sell_limit,
+        symbol,
+        quantity,
+        limitPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_stop_loss(
+    symbol: str,
+    quantity: float,
+    stopPrice: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a stop-loss SELL order."""
+    return await to_thread(
+        rh.order_sell_stop_loss,
+        symbol,
+        quantity,
+        stopPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_stop_limit(
+    symbol: str,
+    quantity: float,
+    limitPrice: float,
+    stopPrice: float,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a stop-limit SELL order."""
+    return await to_thread(
+        rh.order_sell_stop_limit,
+        symbol,
+        quantity,
+        limitPrice,
+        stopPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_trailing_stop(
+    symbol: str,
+    quantity: float,
+    trailAmount: float,
+    trailType: str = "percentage",
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+) -> Any:
+    """Place a trailing-stop SELL order."""
+    return await to_thread(
+        rh.order_sell_trailing_stop,
+        symbol,
+        quantity,
+        trailAmount,
+        trailType=trailType,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order(
+    symbol: str,
+    quantity: float,
+    side: str,
+    limitPrice: Optional[float] = None,
+    stopPrice: Optional[float] = None,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    extendedHours: bool = False,
+    jsonify: bool = True,
+    market_hours: str = "regular_hours",
+) -> Any:
+    """Generic stock order. side: 'buy'/'sell'. Provide limitPrice/stopPrice to vary order type."""
+    return await to_thread(
+        rh.order,
+        symbol,
+        quantity,
+        side,
+        limitPrice=limitPrice,
+        stopPrice=stopPrice,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        extendedHours=extendedHours,
+        jsonify=jsonify,
+        market_hours=market_hours,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Option placement
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_option_credit_spread(
+    price: float,
+    symbol: str,
+    quantity: int,
+    spread: list,
+    timeInForce: str = "gtc",
+    account_number: Optional[str] = None,
+    jsonify: bool = True,
+) -> Any:
+    """Place an option credit spread order. `spread` is a list of leg dicts."""
+    return await to_thread(
+        rh.order_option_credit_spread,
+        price,
+        symbol,
+        quantity,
+        spread,
+        timeInForce=timeInForce,
+        account_number=account_number,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_option_debit_spread(
+    price: float,
+    symbol: str,
+    quantity: int,
+    spread: list,
+    timeInForce: str = "gtc",
+    account_number: Optional[str] = None,
+    jsonify: bool = True,
+) -> Any:
+    """Place an option debit spread order."""
+    return await to_thread(
+        rh.order_option_debit_spread,
+        price,
+        symbol,
+        quantity,
+        spread,
+        timeInForce=timeInForce,
+        account_number=account_number,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_option_spread(
+    direction: str,
+    price: float,
+    symbol: str,
+    quantity: int,
+    spread: list,
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Place a generic option spread order. direction: 'credit'/'debit'."""
+    return await to_thread(
+        rh.order_option_spread,
+        direction,
+        price,
+        symbol,
+        quantity,
+        spread,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_option_limit(
+    positionEffect: str,
+    creditOrDebit: str,
+    price: float,
+    symbol: str,
+    quantity: int,
+    expirationDate: str,
+    strike: float,
+    optionType: str = "both",
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Limit BUY for an option. positionEffect: 'open'/'close'."""
+    return await to_thread(
+        rh.order_buy_option_limit,
+        positionEffect,
+        creditOrDebit,
+        price,
+        symbol,
+        quantity,
+        expirationDate,
+        strike,
+        optionType=optionType,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_option_stop_limit(
+    positionEffect: str,
+    creditOrDebit: str,
+    limitPrice: float,
+    stopPrice: float,
+    symbol: str,
+    quantity: int,
+    expirationDate: str,
+    strike: float,
+    optionType: str = "both",
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Stop-limit BUY for an option."""
+    return await to_thread(
+        rh.order_buy_option_stop_limit,
+        positionEffect,
+        creditOrDebit,
+        limitPrice,
+        stopPrice,
+        symbol,
+        quantity,
+        expirationDate,
+        strike,
+        optionType=optionType,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_option_stop_limit(
+    positionEffect: str,
+    creditOrDebit: str,
+    limitPrice: float,
+    stopPrice: float,
+    symbol: str,
+    quantity: int,
+    expirationDate: str,
+    strike: float,
+    optionType: str = "both",
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Stop-limit SELL for an option."""
+    return await to_thread(
+        rh.order_sell_option_stop_limit,
+        positionEffect,
+        creditOrDebit,
+        limitPrice,
+        stopPrice,
+        symbol,
+        quantity,
+        expirationDate,
+        strike,
+        optionType=optionType,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_option_limit(
+    positionEffect: str,
+    creditOrDebit: str,
+    price: float,
+    symbol: str,
+    quantity: int,
+    expirationDate: str,
+    strike: float,
+    optionType: str = "both",
+    account_number: Optional[str] = None,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Limit SELL for an option."""
+    return await to_thread(
+        rh.order_sell_option_limit,
+        positionEffect,
+        creditOrDebit,
+        price,
+        symbol,
+        quantity,
+        expirationDate,
+        strike,
+        optionType=optionType,
+        account_number=account_number,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Crypto placement
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_crypto_by_price(
+    symbol: str, amountInDollars: float, timeInForce: str = "gtc", jsonify: bool = True
+) -> Any:
+    """Market BUY crypto by dollar amount."""
+    return await to_thread(
+        rh.order_buy_crypto_by_price, symbol, amountInDollars, timeInForce=timeInForce, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_crypto_by_quantity(
+    symbol: str, quantity: float, timeInForce: str = "gtc", jsonify: bool = True
+) -> Any:
+    """Market BUY crypto by quantity."""
+    return await to_thread(
+        rh.order_buy_crypto_by_quantity, symbol, quantity, timeInForce=timeInForce, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_crypto_limit(
+    symbol: str, quantity: float, limitPrice: float, timeInForce: str = "gtc", jsonify: bool = True
+) -> Any:
+    """Limit BUY crypto by quantity."""
+    return await to_thread(
+        rh.order_buy_crypto_limit, symbol, quantity, limitPrice, timeInForce=timeInForce, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_buy_crypto_limit_by_price(
+    symbol: str,
+    amountInDollars: float,
+    limitPrice: float,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Limit BUY crypto by dollar amount."""
+    return await to_thread(
+        rh.order_buy_crypto_limit_by_price,
+        symbol,
+        amountInDollars,
+        limitPrice,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_crypto_by_price(
+    symbol: str, amountInDollars: float, timeInForce: str = "gtc", jsonify: bool = True
+) -> Any:
+    """Market SELL crypto by dollar amount."""
+    return await to_thread(
+        rh.order_sell_crypto_by_price, symbol, amountInDollars, timeInForce=timeInForce, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_crypto_by_quantity(
+    symbol: str, quantity: float, timeInForce: str = "gtc", jsonify: bool = True
+) -> Any:
+    """Market SELL crypto by quantity."""
+    return await to_thread(
+        rh.order_sell_crypto_by_quantity, symbol, quantity, timeInForce=timeInForce, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_crypto_limit(
+    symbol: str, quantity: float, limitPrice: float, timeInForce: str = "gtc", jsonify: bool = True
+) -> Any:
+    """Limit SELL crypto by quantity."""
+    return await to_thread(
+        rh.order_sell_crypto_limit, symbol, quantity, limitPrice, timeInForce=timeInForce, jsonify=jsonify
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_sell_crypto_limit_by_price(
+    symbol: str,
+    amountInDollars: float,
+    limitPrice: float,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Limit SELL crypto by dollar amount."""
+    return await to_thread(
+        rh.order_sell_crypto_limit_by_price,
+        symbol,
+        amountInDollars,
+        limitPrice,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def rh_order_crypto(
+    symbol: str,
+    side: str,
+    quantityOrPrice: float,
+    amountIn: str = "quantity",
+    limitPrice: Optional[float] = None,
+    timeInForce: str = "gtc",
+    jsonify: bool = True,
+) -> Any:
+    """Generic crypto order. side: 'buy'/'sell'. amountIn: 'quantity'/'dollars'."""
+    return await to_thread(
+        rh.order_crypto,
+        symbol,
+        side,
+        quantityOrPrice,
+        amountIn=amountIn,
+        limitPrice=limitPrice,
+        timeInForce=timeInForce,
+        jsonify=jsonify,
+    )

--- a/robin_stocks_mcp/tools/robinhood_profiles.py
+++ b/robin_stocks_mcp/tools/robinhood_profiles.py
@@ -1,0 +1,60 @@
+"""Robinhood profile tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_account_profile(
+    account_number: Optional[str] = None,
+    info: Optional[str] = None,
+    dataType: str = "indexzero",
+) -> Any:
+    """Account profile: day-trading info, cash held by Robinhood, settled funds."""
+    return await to_thread(
+        rh.load_account_profile, account_number=account_number, info=info, dataType=dataType
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_basic_profile(info: Optional[str] = None) -> Any:
+    """Personal profile: phone, city, marital status, date of birth."""
+    return await to_thread(rh.load_basic_profile, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_investment_profile(info: Optional[str] = None) -> Any:
+    """Investment profile from the new-account questionnaire."""
+    return await to_thread(rh.load_investment_profile, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_portfolio_profile(
+    account_number: Optional[str] = None, info: Optional[str] = None
+) -> Any:
+    """Portfolio profile: withdrawable amount, market value, excess margin."""
+    return await to_thread(rh.load_portfolio_profile, account_number=account_number, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_security_profile(info: Optional[str] = None) -> Any:
+    """Security profile."""
+    return await to_thread(rh.load_security_profile, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_load_user_profile(info: Optional[str] = None) -> Any:
+    """User profile: username, email, links to other profiles."""
+    return await to_thread(rh.load_user_profile, info=info)

--- a/robin_stocks_mcp/tools/robinhood_stocks.py
+++ b/robin_stocks_mcp/tools/robinhood_stocks.py
@@ -1,0 +1,161 @@
+"""Robinhood stock-data tools."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Union
+
+import robin_stocks.robinhood as rh
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+Symbols = Union[str, List[str]]
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_quotes(inputSymbols: Symbols, info: Optional[str] = None) -> Any:
+    """Quote info (bid/ask/last price/volume) for one or more tickers."""
+    return await to_thread(rh.get_quotes, inputSymbols, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_fundamentals(inputSymbols: Symbols, info: Optional[str] = None) -> Any:
+    """Fundamentals for one or more tickers: sector, description, dividend yield, market cap."""
+    return await to_thread(rh.get_fundamentals, inputSymbols, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_instruments_by_symbols(
+    inputSymbols: Symbols, info: Optional[str] = None
+) -> Any:
+    """Instrument metadata held by the market (bloomberg id, listing date, etc.)."""
+    return await to_thread(rh.get_instruments_by_symbols, inputSymbols, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_instrument_by_url(url: str, info: Optional[str] = None) -> Any:
+    """Instrument data given the canonical instrument URL."""
+    return await to_thread(rh.get_instrument_by_url, url, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_latest_price(
+    inputSymbols: Symbols,
+    priceType: Optional[str] = None,
+    includeExtendedHours: bool = True,
+) -> Any:
+    """Latest price for each ticker, returned as a list of strings."""
+    return await to_thread(
+        rh.get_latest_price, inputSymbols, priceType=priceType, includeExtendedHours=includeExtendedHours
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_name_by_symbol(symbol: str) -> Any:
+    """Stock name from the ticker."""
+    return await to_thread(rh.get_name_by_symbol, symbol)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_name_by_url(url: str) -> Any:
+    """Stock name from the instrument URL."""
+    return await to_thread(rh.get_name_by_url, url)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_symbol_by_url(url: str) -> Any:
+    """Stock symbol from the instrument URL."""
+    return await to_thread(rh.get_symbol_by_url, url)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_ratings(symbol: str, info: Optional[str] = None) -> Any:
+    """Analyst ratings (buy/hold/sell counts) for a stock."""
+    return await to_thread(rh.get_ratings, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_events(symbol: str, info: Optional[str] = None) -> Any:
+    """Events related to a stock that the user owns."""
+    return await to_thread(rh.get_events, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_earnings(symbol: str, info: Optional[str] = None) -> Any:
+    """Earnings reports for the different financial quarters."""
+    return await to_thread(rh.get_earnings, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_news(symbol: str, info: Optional[str] = None) -> Any:
+    """News stories for a stock."""
+    return await to_thread(rh.get_news, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_splits(symbol: str, info: Optional[str] = None) -> Any:
+    """Stock splits (date, divisor, multiplier)."""
+    return await to_thread(rh.get_splits, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_find_instrument_data(query: str) -> Any:
+    """Search for instruments matching the query keyword."""
+    return await to_thread(rh.find_instrument_data, query)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_stock_historicals(
+    inputSymbols: Symbols,
+    interval: str = "hour",
+    span: str = "week",
+    bounds: str = "regular",
+    info: Optional[str] = None,
+) -> Any:
+    """Historical OHLC for stocks. interval: 5/10minute, hour, day, week. span: day..5year, all."""
+    return await to_thread(
+        rh.get_stock_historicals, inputSymbols, interval=interval, span=span, bounds=bounds, info=info
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_stock_quote_by_id(stock_id: str, info: Optional[str] = None) -> Any:
+    """Quote info for a single stock by Robinhood instrument id."""
+    return await to_thread(rh.get_stock_quote_by_id, stock_id, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_stock_quote_by_symbol(symbol: str, info: Optional[str] = None) -> Any:
+    """Quote info for a single stock by ticker symbol."""
+    return await to_thread(rh.get_stock_quote_by_symbol, symbol, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_pricebook_by_id(stock_id: str, info: Optional[str] = None) -> Any:
+    """Order pricebook (level-2 quotes) by instrument id. Requires Robinhood Gold."""
+    return await to_thread(rh.get_pricebook_by_id, stock_id, info=info)
+
+
+@mcp.tool()
+@safe_tool()
+async def rh_get_pricebook_by_symbol(symbol: str, info: Optional[str] = None) -> Any:
+    """Order pricebook (level-2 quotes) by symbol. Requires Robinhood Gold."""
+    return await to_thread(rh.get_pricebook_by_symbol, symbol, info=info)

--- a/robin_stocks_mcp/tools/tda_account.py
+++ b/robin_stocks_mcp/tools/tda_account.py
@@ -1,0 +1,57 @@
+"""TD Ameritrade account tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.tda as tda
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_accounts(options: Optional[str] = None, jsonify: Optional[bool] = None) -> Any:
+    """Get all TDA accounts. `options`: comma-separated 'positions,orders'."""
+    return await to_thread(tda.get_accounts, options=options, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_account(
+    id: str, options: Optional[str] = None, jsonify: Optional[bool] = None
+) -> Any:
+    """Get account information for a specific TDA account id."""
+    return await to_thread(tda.get_account, id, options=options, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_transactions(
+    id: str,
+    type_value: Optional[str] = None,
+    symbol: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """Transactions for a TDA account, optionally filtered by type, symbol, date range."""
+    return await to_thread(
+        tda.get_transactions,
+        id,
+        type_value=type_value,
+        symbol=symbol,
+        start_date=start_date,
+        end_date=end_date,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_transaction(
+    account_id: str, transaction_id: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Get information for a single TDA transaction."""
+    return await to_thread(tda.get_transaction, account_id, transaction_id, jsonify=jsonify)

--- a/robin_stocks_mcp/tools/tda_auth.py
+++ b/robin_stocks_mcp/tools/tda_auth.py
@@ -1,0 +1,41 @@
+"""TD Ameritrade authentication tools."""
+
+from __future__ import annotations
+
+import robin_stocks.tda as tda
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_login(encryption_passcode: str) -> str:
+    """Log in to TD Ameritrade. Requires a previous `tda_login_first_time` to seed credentials."""
+    await to_thread(tda.login, encryption_passcode)
+    return "ok: TDA login complete"
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_login_first_time(
+    encryption_passcode: str,
+    client_id: str,
+    authorization_token: str,
+    refresh_token: str,
+) -> str:
+    """Persist TDA OAuth tokens encrypted on disk for future logins.
+
+    Run once after going through the TDA developer-portal OAuth flow.
+    """
+    await to_thread(
+        tda.login_first_time, encryption_passcode, client_id, authorization_token, refresh_token
+    )
+    return "ok: TDA credentials saved"
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_generate_encryption_passcode() -> str:
+    """Generate a fresh encryption passcode for storing TDA credentials."""
+    return await to_thread(tda.generate_encryption_passcode)

--- a/robin_stocks_mcp/tools/tda_markets.py
+++ b/robin_stocks_mcp/tools/tda_markets.py
@@ -1,0 +1,37 @@
+"""TD Ameritrade market tools."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Union
+
+import robin_stocks.tda as tda
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_hours_for_markets(
+    markets: Union[str, List[str]], date: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Market hours for one or more markets on a given date (YYYY-MM-DD)."""
+    return await to_thread(tda.get_hours_for_markets, markets, date, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_hours_for_market(
+    market: str, date: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Market hours for a single market on a given date."""
+    return await to_thread(tda.get_hours_for_market, market, date, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_movers(
+    market: str, direction: str, change: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Market movers. market: $DJI / $COMPX / $SPX.X. direction: up/down. change: percent/value."""
+    return await to_thread(tda.get_movers, market, direction, change, jsonify=jsonify)

--- a/robin_stocks_mcp/tools/tda_orders.py
+++ b/robin_stocks_mcp/tools/tda_orders.py
@@ -1,0 +1,59 @@
+"""TD Ameritrade order tools."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import robin_stocks.tda as tda
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def tda_place_order(
+    account_id: str, order_payload: dict, jsonify: Optional[bool] = None
+) -> Any:
+    """Place an order on a TDA account. `order_payload` follows the TDA Orders API schema."""
+    return await to_thread(tda.place_order, account_id, order_payload, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool(write=True)
+async def tda_cancel_order(
+    account_id: str, order_id: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Cancel an existing TDA order."""
+    return await to_thread(tda.cancel_order, account_id, order_id, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_order(
+    account_id: str, order_id: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Get information about a single TDA order."""
+    return await to_thread(tda.get_order, account_id, order_id, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_orders_for_account(
+    account_id: str,
+    max_results: Optional[int] = None,
+    from_time: Optional[str] = None,
+    to_time: Optional[str] = None,
+    status: Optional[str] = None,
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """List orders on a TDA account, optionally filtered."""
+    return await to_thread(
+        tda.get_orders_for_account,
+        account_id,
+        max_results=max_results,
+        from_time=from_time,
+        to_time=to_time,
+        status=status,
+        jsonify=jsonify,
+    )

--- a/robin_stocks_mcp/tools/tda_stocks.py
+++ b/robin_stocks_mcp/tools/tda_stocks.py
@@ -1,0 +1,116 @@
+"""TD Ameritrade stock-data tools."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Union
+
+import robin_stocks.tda as tda
+
+from ..app import mcp
+from ..runtime import safe_tool, to_thread
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_quote(ticker: str, jsonify: Optional[bool] = None) -> Any:
+    """Quote info for a single stock via TDA."""
+    return await to_thread(tda.get_quote, ticker, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_quotes(tickers: Union[str, List[str]], jsonify: Optional[bool] = None) -> Any:
+    """Quote info for multiple stocks via TDA."""
+    return await to_thread(tda.get_quotes, tickers, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_price_history(
+    ticker: str,
+    period_type: str,
+    frequency_type: str,
+    frequency: str,
+    period: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    needExtendedHoursData: bool = True,
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """Price history for a stock.
+
+    period_type: day / month / year / ytd
+    frequency_type: minute / daily / weekly / monthly
+    """
+    return await to_thread(
+        tda.get_price_history,
+        ticker,
+        period_type,
+        frequency_type,
+        frequency,
+        period=period,
+        start_date=start_date,
+        end_date=end_date,
+        needExtendedHoursData=needExtendedHoursData,
+        jsonify=jsonify,
+    )
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_search_instruments(
+    ticker_string: str, projection: str, jsonify: Optional[bool] = None
+) -> Any:
+    """Search instruments matching a ticker string. projection: symbol-search / symbol-regex / desc-search / desc-regex / fundamental."""
+    return await to_thread(tda.search_instruments, ticker_string, projection, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_instrument(cusip: str, jsonify: Optional[bool] = None) -> Any:
+    """Get instrument data by CUSIP."""
+    return await to_thread(tda.get_instrument, cusip, jsonify=jsonify)
+
+
+@mcp.tool()
+@safe_tool()
+async def tda_get_option_chains(
+    ticker: str,
+    contract_type: str = "ALL",
+    strike_count: str = "10",
+    include_quotes: str = "FALSE",
+    strategy: str = "SINGLE",
+    interval: Optional[str] = None,
+    strike_price: Optional[str] = None,
+    range_value: str = "ALL",
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    volatility: Optional[str] = None,
+    underlying_price: Optional[str] = None,
+    interest_rate: Optional[str] = None,
+    days_to_expiration: Optional[str] = None,
+    exp_month: str = "ALL",
+    option_type: str = "ALL",
+    jsonify: Optional[bool] = None,
+) -> Any:
+    """Option chain data for a stock via TDA."""
+    return await to_thread(
+        tda.get_option_chains,
+        ticker,
+        contract_type=contract_type,
+        strike_count=strike_count,
+        include_quotes=include_quotes,
+        strategy=strategy,
+        interval=interval,
+        strike_price=strike_price,
+        range_value=range_value,
+        from_date=from_date,
+        to_date=to_date,
+        volatility=volatility,
+        underlying_price=underlying_price,
+        interest_rate=interest_rate,
+        days_to_expiration=days_to_expiration,
+        exp_month=exp_month,
+        option_type=option_type,
+        jsonify=jsonify,
+    )

--- a/setup.py
+++ b/setup.py
@@ -7,22 +7,31 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='robin_stocks',
-      version='3.4.0',
-      description='A Python wrapper around the Robinhood API',
+      version='3.5.0',
+      description='A Python wrapper around the Robinhood API (with an optional MCP server)',
       long_description=long_description,
       long_description_content_type='text/x-rst',
       url='https://github.com/jmfernandes/robin_stocks',
       author='Josh Fernandes',
       author_email='joshfernandes@mac.com',
-      keywords=['robinhood','robin stocks','finance app','stocks','options','trading','investing'],
+      keywords=['robinhood','robin stocks','finance app','stocks','options','trading','investing','mcp'],
       license='MIT',
-      python_requires='>=3.9',
-      packages=find_packages(),
-      requires=['requests', 'pyotp', 'cryptography'],
+      python_requires='>=3.10',
+      packages=find_packages(include=['robin_stocks', 'robin_stocks.*',
+                                      'robin_stocks_mcp', 'robin_stocks_mcp.*']),
       install_requires=[
           'requests',
           'pyotp',
           'python-dotenv',
-          'cryptography'
+          'cryptography',
       ],
+      extras_require={
+          'mcp': ['mcp[cli]>=1.2.0'],
+          'dev': ['pytest', 'pytest-asyncio', 'pytest-timeout', 'pytest-dotenv'],
+      },
+      entry_points={
+          'console_scripts': [
+              'robin-stocks-mcp=robin_stocks_mcp.server:main',
+          ],
+      },
       zip_safe=False)

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,95 @@
+"""Shared test fixtures for the robin_stocks_mcp test suite."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from typing import Any, Callable
+
+import pytest
+
+from robin_stocks_mcp import runtime
+from robin_stocks_mcp.app import mcp as mcp_app
+from robin_stocks_mcp.config import Config
+
+
+def _import_all_tool_modules() -> None:
+    """Force-import every tool module so the FastMCP instance is fully populated."""
+    from robin_stocks_mcp.tools import (  # noqa: F401
+        robinhood_auth,
+        robinhood_account,
+        robinhood_profiles,
+        robinhood_stocks,
+        robinhood_options,
+        robinhood_crypto,
+        robinhood_markets,
+        robinhood_orders,
+        robinhood_export,
+        tda_auth,
+        tda_account,
+        tda_stocks,
+        tda_markets,
+        tda_orders,
+        gemini_auth,
+        gemini_account,
+        gemini_crypto,
+        gemini_orders,
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _register_tools() -> None:
+    """Import every tool module exactly once for the test session.
+
+    Tool modules that can't be imported (because they don't exist yet) are skipped silently
+    so partial test runs work during incremental development.
+    """
+    try:
+        _import_all_tool_modules()
+    except ImportError:
+        pass
+
+
+@pytest.fixture
+def writes_enabled() -> Any:
+    """Temporarily disable the read-only guard for write-tool tests."""
+    original = runtime.get_config()
+    runtime.set_config(Config(**{**original.__dict__, "read_only": False}))
+    yield
+    runtime.set_config(original)
+
+
+@pytest.fixture
+def writes_disabled() -> Any:
+    """Force the read-only guard on."""
+    original = runtime.get_config()
+    runtime.set_config(Config(**{**original.__dict__, "read_only": True}))
+    yield
+    runtime.set_config(original)
+
+
+def get_tool_fn(name: str) -> Callable[..., Any]:
+    """Look up a registered FastMCP tool's underlying async function by name."""
+    tool = mcp_app._tool_manager.get_tool(name)
+    if tool is None:
+        raise KeyError(f"tool '{name}' is not registered")
+    return tool.fn
+
+
+def call_tool(name: str, **kwargs: Any) -> Any:
+    """Synchronously invoke a registered tool (waits for the coroutine to finish)."""
+    fn = get_tool_fn(name)
+    coro = fn(**kwargs)
+    if asyncio.iscoroutine(coro):
+        return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+    return coro
+
+
+@pytest.fixture
+def call() -> Callable[..., Any]:
+    return call_tool
+
+
+@pytest.fixture
+def get_fn() -> Callable[..., Callable[..., Any]]:
+    return get_tool_fn

--- a/tests/mcp/test_auth_bootstrap.py
+++ b/tests/mcp/test_auth_bootstrap.py
@@ -1,0 +1,191 @@
+"""Tests for the auth bootstrap.
+
+Order of preference at startup:
+  1. SDK-persisted session (Robinhood pickle / TDA encrypted store)
+  2. Env-supplied credentials
+  3. No-op + helpful log message
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+from unittest.mock import MagicMock, patch
+
+from robin_stocks_mcp.auth import (
+    _robinhood_pickle_path,
+    bootstrap_login,
+    try_reuse_robinhood_session,
+)
+from robin_stocks_mcp.config import Config
+
+
+def _cfg(**overrides) -> Config:
+    base = dict(
+        read_only=True,
+        auto_login=True,
+        rh_username=None,
+        rh_password=None,
+        rh_mfa_code=None,
+        rh_pickle_path=None,
+        rh_pickle_name=None,
+        tda_encryption_passcode=None,
+        gemini_api_key=None,
+        gemini_secret_key=None,
+        gemini_sandbox=False,
+    )
+    base.update(overrides)
+    return Config(**base)
+
+
+# ---------------------------------------------------------------------------
+# Pickle-reuse path (the primary, recommended flow)
+# ---------------------------------------------------------------------------
+
+
+def test_try_reuse_returns_false_when_no_pickle(tmp_path) -> None:
+    cfg = _cfg(rh_pickle_path=str(tmp_path))
+    assert try_reuse_robinhood_session(cfg) is False
+
+
+def test_try_reuse_loads_pickle_and_probes_api(tmp_path) -> None:
+    cfg = _cfg(rh_pickle_path=str(tmp_path))
+    pickle_path = _robinhood_pickle_path(cfg)
+    with open(pickle_path, "wb") as f:
+        pickle.dump(
+            {
+                "token_type": "Bearer",
+                "access_token": "tok-123",
+                "refresh_token": "ref-123",
+                "device_token": "dev-123",
+            },
+            f,
+        )
+
+    fake_response = MagicMock()
+    fake_response.raise_for_status.return_value = None
+
+    with patch("robin_stocks_mcp.auth.request_get", return_value=fake_response) as probe, \
+         patch("robin_stocks_mcp.auth.update_session") as upd, \
+         patch("robin_stocks_mcp.auth.set_login_state") as state:
+        ok = try_reuse_robinhood_session(cfg)
+
+    assert ok is True
+    probe.assert_called_once()
+    upd.assert_any_call("Authorization", "Bearer tok-123")
+    state.assert_called_once_with(True)
+
+
+def test_try_reuse_returns_false_on_invalid_token(tmp_path) -> None:
+    cfg = _cfg(rh_pickle_path=str(tmp_path))
+    pickle_path = _robinhood_pickle_path(cfg)
+    with open(pickle_path, "wb") as f:
+        pickle.dump(
+            {
+                "token_type": "Bearer",
+                "access_token": "expired",
+                "refresh_token": "x",
+                "device_token": "x",
+            },
+            f,
+        )
+
+    fake_response = MagicMock()
+    fake_response.raise_for_status.side_effect = Exception("401 Unauthorized")
+
+    with patch("robin_stocks_mcp.auth.request_get", return_value=fake_response), \
+         patch("robin_stocks_mcp.auth.update_session"), \
+         patch("robin_stocks_mcp.auth.set_login_state"):
+        ok = try_reuse_robinhood_session(cfg)
+
+    assert ok is False
+
+
+def test_bootstrap_prefers_pickle_over_env_creds(tmp_path) -> None:
+    cfg = _cfg(
+        rh_pickle_path=str(tmp_path),
+        rh_username="from-env",
+        rh_password="from-env",
+    )
+    with patch(
+        "robin_stocks_mcp.auth.try_reuse_robinhood_session", return_value=True
+    ) as reuse, patch("robin_stocks.robinhood.login") as rh_login:
+        bootstrap_login(cfg)
+
+    reuse.assert_called_once()
+    # Env creds must NOT be used when the pickle works.
+    rh_login.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Env-fallback path
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_falls_back_to_env_creds_when_pickle_missing() -> None:
+    cfg = _cfg(rh_username="u", rh_password="p", rh_mfa_code="123456")
+    with patch(
+        "robin_stocks_mcp.auth.try_reuse_robinhood_session", return_value=False
+    ), patch("robin_stocks.robinhood.login") as rh_login:
+        bootstrap_login(cfg)
+
+    rh_login.assert_called_once()
+    _, kwargs = rh_login.call_args
+    assert kwargs["username"] == "u"
+    assert kwargs["password"] == "p"
+    assert kwargs["mfa_code"] == "123456"
+
+
+def test_bootstrap_no_op_when_nothing_configured() -> None:
+    cfg = _cfg()
+    with patch(
+        "robin_stocks_mcp.auth.try_reuse_robinhood_session", return_value=False
+    ), patch("robin_stocks.robinhood.login") as rh_login, patch(
+        "robin_stocks.tda.login"
+    ) as tda_login, patch("robin_stocks.gemini.login") as gem_login:
+        bootstrap_login(cfg)
+
+    rh_login.assert_not_called()
+    tda_login.assert_not_called()
+    gem_login.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TDA + Gemini still env-driven
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_tda_when_passcode_set() -> None:
+    with patch("robin_stocks_mcp.auth.try_reuse_robinhood_session", return_value=False), \
+         patch("robin_stocks.tda.login") as tda_login:
+        bootstrap_login(_cfg(tda_encryption_passcode="pp"))
+    tda_login.assert_called_once_with("pp")
+
+
+def test_bootstrap_gemini_sandbox() -> None:
+    with patch("robin_stocks_mcp.auth.try_reuse_robinhood_session", return_value=False), \
+         patch("robin_stocks.gemini.login") as gem_login, \
+         patch("robin_stocks.gemini.use_sand_box_urls") as sandbox:
+        bootstrap_login(
+            _cfg(gemini_api_key="k", gemini_secret_key="s", gemini_sandbox=True)
+        )
+    sandbox.assert_called_once_with(True)
+    gem_login.assert_called_once_with("k", "s")
+
+
+def test_bootstrap_skipped_when_auto_login_disabled() -> None:
+    with patch("robin_stocks_mcp.auth.try_reuse_robinhood_session") as reuse, \
+         patch("robin_stocks.robinhood.login") as rh_login:
+        bootstrap_login(_cfg(auto_login=False, rh_username="u", rh_password="p"))
+    reuse.assert_not_called()
+    rh_login.assert_not_called()
+
+
+def test_bootstrap_isolated_failures() -> None:
+    """A broker failing must not abort the whole bootstrap or block the others."""
+    with patch(
+        "robin_stocks_mcp.auth.try_reuse_robinhood_session",
+        side_effect=Exception("boom"),
+    ), patch("robin_stocks.tda.login") as tda_login:
+        bootstrap_login(_cfg(tda_encryption_passcode="pp"))  # must not raise
+    tda_login.assert_called_once_with("pp")

--- a/tests/mcp/test_cli.py
+++ b/tests/mcp/test_cli.py
@@ -1,0 +1,88 @@
+"""Tests for the `robin-stocks-mcp` CLI subcommands (login, tda-setup, logout)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from robin_stocks_mcp.server import main
+
+
+def test_default_command_is_serve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare `robin-stocks-mcp` (no subcommand) should default to serve."""
+    with patch("robin_stocks_mcp.server._cmd_serve", return_value=0) as serve, \
+         patch("robin_stocks_mcp.server.bootstrap_login"):
+        rc = main([])
+    serve.assert_called_once()
+    assert rc == 0
+
+
+def test_legacy_transport_flag_still_works() -> None:
+    """`robin-stocks-mcp --transport stdio` (old form) still routes to serve."""
+    with patch("robin_stocks_mcp.server._cmd_serve", return_value=0) as serve:
+        main(["--transport", "stdio"])
+    serve.assert_called_once()
+    args = serve.call_args[0][0]
+    assert args.transport == "stdio"
+
+
+def test_login_subcommand_calls_rh_login() -> None:
+    with patch("robin_stocks.robinhood.login") as rh_login:
+        main([
+            "login",
+            "--username", "u",
+            "--password", "p",
+            "--mfa-code", "123456",
+        ])
+    rh_login.assert_called_once()
+    _, kwargs = rh_login.call_args
+    assert kwargs["username"] == "u"
+    assert kwargs["password"] == "p"
+    assert kwargs["mfa_code"] == "123456"
+    assert kwargs["store_session"] is True
+
+
+def test_tda_setup_calls_login_first_time() -> None:
+    with patch("robin_stocks.tda.login_first_time") as setup:
+        main([
+            "tda-setup",
+            "--passcode", "pp",
+            "--client-id", "cid",
+            "--auth-token", "auth",
+            "--refresh-token", "ref",
+        ])
+    setup.assert_called_once_with("pp", "cid", "auth", "ref")
+
+
+def test_tda_setup_generates_passcode_when_flag_given(capsys) -> None:
+    with patch("robin_stocks.tda.generate_encryption_passcode", return_value="GEN-PASS"), \
+         patch("robin_stocks.tda.login_first_time") as setup:
+        main([
+            "tda-setup",
+            "--generate-passcode",
+            "--client-id", "cid",
+            "--auth-token", "auth",
+            "--refresh-token", "ref",
+        ])
+    setup.assert_called_once()
+    args, _ = setup.call_args
+    assert args[0] == "GEN-PASS"
+    out = capsys.readouterr().out
+    assert "GEN-PASS" in out
+
+
+def test_logout_clears_both_brokers_by_default() -> None:
+    with patch("robin_stocks.robinhood.logout") as rh_out, \
+         patch("robin_stocks.gemini.logout") as gem_out:
+        main(["logout"])
+    rh_out.assert_called_once()
+    gem_out.assert_called_once()
+
+
+def test_logout_can_target_one_broker() -> None:
+    with patch("robin_stocks.robinhood.logout") as rh_out, \
+         patch("robin_stocks.gemini.logout") as gem_out:
+        main(["logout", "rh"])
+    rh_out.assert_called_once()
+    gem_out.assert_not_called()

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -1,0 +1,64 @@
+"""Tests for env-var driven configuration."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from robin_stocks_mcp import config as config_mod
+
+
+def reload_config(monkeypatch: pytest.MonkeyPatch, **env: str) -> config_mod.Config:
+    for k in list(env.keys()):
+        monkeypatch.setenv(k, env[k])
+    importlib.reload(config_mod)
+    return config_mod.load_config()
+
+
+def test_read_only_default_is_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ROBIN_STOCKS_MCP_READ_ONLY", raising=False)
+    cfg = config_mod.load_config()
+    assert cfg.read_only is True
+
+
+@pytest.mark.parametrize("val,expected", [
+    ("true", True),
+    ("1", True),
+    ("yes", True),
+    ("y", True),
+    ("on", True),
+    ("no", False),
+    ("0", False),
+    ("false", False),
+    ("off", False),
+])
+def test_bool_env_parser(monkeypatch: pytest.MonkeyPatch, val: str, expected: bool) -> None:
+    # Use a different env var to test the helper directly
+    monkeypatch.setenv("ROBIN_STOCKS_MCP_AUTO_LOGIN", val)
+    cfg = config_mod.load_config()
+    assert cfg.auto_login is expected
+
+
+def test_credentials_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ROBINHOOD_USERNAME", "user")
+    monkeypatch.setenv("ROBINHOOD_PASSWORD", "pass")
+    monkeypatch.setenv("TDA_ENCRYPTION_PASSCODE", "pass-code")
+    monkeypatch.setenv("GEMINI_API_KEY", "k")
+    monkeypatch.setenv("GEMINI_SECRET_KEY", "s")
+    cfg = config_mod.load_config()
+    assert cfg.rh_username == "user"
+    assert cfg.rh_password == "pass"
+    assert cfg.tda_encryption_passcode == "pass-code"
+    assert cfg.gemini_api_key == "k"
+    assert cfg.gemini_secret_key == "s"
+
+
+def test_rh_alias_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ROBINHOOD_USERNAME", raising=False)
+    monkeypatch.delenv("ROBINHOOD_PASSWORD", raising=False)
+    monkeypatch.setenv("RH_USERNAME", "alt")
+    monkeypatch.setenv("RH_PASSWORD", "altpass")
+    cfg = config_mod.load_config()
+    assert cfg.rh_username == "alt"
+    assert cfg.rh_password == "altpass"

--- a/tests/mcp/test_gemini_tools.py
+++ b/tests/mcp/test_gemini_tools.py
@@ -1,0 +1,100 @@
+"""Tests that Gemini tools dispatch correctly to the SDK."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from robin_stocks_mcp.app import mcp
+
+
+def get_fn(name: str):
+    return mcp._tool_manager.get_tool(name).fn
+
+
+@pytest.mark.asyncio
+async def test_gem_login_dispatches() -> None:
+    with patch("robin_stocks.gemini.login") as m:
+        out = await get_fn("gem_login")(api_key="k", secret_key="s")
+        m.assert_called_once_with("k", "s")
+        assert out == "ok: Gemini login complete"
+
+
+@pytest.mark.asyncio
+async def test_gem_get_pubticker_dispatches() -> None:
+    with patch("robin_stocks.gemini.get_pubticker", return_value={"last": "1"}) as m:
+        await get_fn("gem_get_pubticker")(ticker="btcusd")
+        m.assert_called_once_with("btcusd", jsonify=None)
+
+
+@pytest.mark.asyncio
+async def test_gem_check_available_balances_dispatches() -> None:
+    with patch("robin_stocks.gemini.check_available_balances", return_value=[]) as m:
+        await get_fn("gem_check_available_balances")()
+        m.assert_called_once_with(jsonify=None)
+
+
+@pytest.mark.asyncio
+async def test_gem_order_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.gemini.order") as m:
+        out = await get_fn("gem_order")(symbol="btcusd", side="buy", quantity=1.0)
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gem_order_dispatches_when_enabled(writes_enabled) -> None:
+    with patch("robin_stocks.gemini.order", return_value={"order_id": "x"}) as m:
+        out = await get_fn("gem_order")(symbol="btcusd", side="buy", quantity=1.0, price=50000.0)
+        m.assert_called_once_with(
+            "btcusd",
+            "buy",
+            1.0,
+            price=50000.0,
+            order_type="exchange limit",
+            options=None,
+            jsonify=None,
+        )
+        assert out == {"order_id": "x"}
+
+
+@pytest.mark.asyncio
+async def test_gem_order_market_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.gemini.order_market") as m:
+        out = await get_fn("gem_order_market")(symbol="btcusd", side="buy", quantity=1.0)
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gem_cancel_all_active_orders_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.gemini.cancel_all_active_orders") as m:
+        out = await get_fn("gem_cancel_all_active_orders")()
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gem_withdraw_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.gemini.withdraw_crypto_funds") as m:
+        out = await get_fn("gem_withdraw_crypto_funds")(
+            address="addr", amount=1.0, currency="btc"
+        )
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gem_use_sandbox_dispatches() -> None:
+    with patch("robin_stocks.gemini.use_sand_box_urls") as m:
+        out = await get_fn("gem_use_sandbox")(use_sandbox=True)
+        m.assert_called_once_with(True)
+        assert out == "ok: Gemini sandbox=on"
+
+
+@pytest.mark.asyncio
+async def test_gem_heartbeat_dispatches() -> None:
+    with patch("robin_stocks.gemini.heartbeat", return_value={"result": "ok"}) as m:
+        await get_fn("gem_heartbeat")()
+        m.assert_called_once_with(jsonify=None)

--- a/tests/mcp/test_robinhood_tools.py
+++ b/tests/mcp/test_robinhood_tools.py
@@ -1,0 +1,168 @@
+"""Tests that Robinhood tools dispatch correctly to the SDK and honour the read-only guard."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from robin_stocks_mcp.app import mcp
+
+
+def get_fn(name: str):
+    tool = mcp._tool_manager.get_tool(name)
+    assert tool is not None, f"tool '{name}' not registered"
+    return tool.fn
+
+
+# ---------------------------------------------------------------------------
+# Read-tool dispatch: each one should call the underlying SDK function exactly once
+# and pass its arguments through.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rh_get_quotes_dispatches() -> None:
+    with patch("robin_stocks.robinhood.get_quotes", return_value=[{"symbol": "AAPL"}]) as m:
+        out = await get_fn("rh_get_quotes")(inputSymbols="AAPL")
+        m.assert_called_once_with("AAPL", info=None)
+        assert out == [{"symbol": "AAPL"}]
+
+
+@pytest.mark.asyncio
+async def test_rh_get_latest_price_dispatches() -> None:
+    with patch("robin_stocks.robinhood.get_latest_price", return_value=["100.00"]) as m:
+        out = await get_fn("rh_get_latest_price")(inputSymbols=["AAPL", "MSFT"])
+        m.assert_called_once_with(["AAPL", "MSFT"], priceType=None, includeExtendedHours=True)
+        assert out == ["100.00"]
+
+
+@pytest.mark.asyncio
+async def test_rh_build_holdings_dispatches() -> None:
+    with patch("robin_stocks.robinhood.build_holdings", return_value={"AAPL": {}}) as m:
+        out = await get_fn("rh_build_holdings")(with_dividends=True)
+        m.assert_called_once_with(with_dividends=True)
+        assert out == {"AAPL": {}}
+
+
+@pytest.mark.asyncio
+async def test_rh_get_market_hours_dispatches() -> None:
+    with patch("robin_stocks.robinhood.get_market_hours", return_value={"opens_at": "9:30"}) as m:
+        await get_fn("rh_get_market_hours")(market="XNYS", date="2026-05-19")
+        m.assert_called_once_with("XNYS", "2026-05-19", info=None)
+
+
+@pytest.mark.asyncio
+async def test_rh_get_crypto_quote_dispatches() -> None:
+    with patch("robin_stocks.robinhood.get_crypto_quote", return_value={"high_price": "1"}) as m:
+        await get_fn("rh_get_crypto_quote")(symbol="BTC")
+        m.assert_called_once_with("BTC", info=None)
+
+
+@pytest.mark.asyncio
+async def test_rh_find_tradable_options_dispatches() -> None:
+    with patch("robin_stocks.robinhood.find_tradable_options", return_value=[]) as m:
+        await get_fn("rh_find_tradable_options")(symbol="AAPL", expirationDate="2026-06-19")
+        m.assert_called_once_with(
+            "AAPL", expirationDate="2026-06-19", strikePrice=None, optionType=None, info=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_rh_find_stock_orders_unpacks_filters() -> None:
+    with patch("robin_stocks.robinhood.find_stock_orders", return_value=[]) as m:
+        await get_fn("rh_find_stock_orders")(filters={"state": "filled", "side": "buy"})
+        m.assert_called_once_with(state="filled", side="buy")
+
+
+# ---------------------------------------------------------------------------
+# Write-tool dispatch + read-only enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rh_order_buy_market_blocked_when_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.robinhood.order_buy_market") as m:
+        out = await get_fn("rh_order_buy_market")(symbol="AAPL", quantity=1)
+        assert out["error"] is True
+        assert out["type"] == "ReadOnlyError"
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rh_order_buy_market_dispatches_when_writes_enabled(writes_enabled) -> None:
+    with patch("robin_stocks.robinhood.order_buy_market", return_value={"id": "abc"}) as m:
+        out = await get_fn("rh_order_buy_market")(symbol="AAPL", quantity=1)
+        m.assert_called_once_with(
+            "AAPL",
+            1,
+            account_number=None,
+            timeInForce="gtc",
+            extendedHours=False,
+            jsonify=True,
+        )
+        assert out == {"id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_rh_cancel_all_stock_orders_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.robinhood.cancel_all_stock_orders") as m:
+        out = await get_fn("rh_cancel_all_stock_orders")()
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rh_order_buy_limit_dispatches(writes_enabled) -> None:
+    with patch("robin_stocks.robinhood.order_buy_limit", return_value={"id": "x"}) as m:
+        await get_fn("rh_order_buy_limit")(symbol="AAPL", quantity=1, limitPrice=100.0)
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        assert args == ("AAPL", 1, 100.0)
+
+
+@pytest.mark.asyncio
+async def test_rh_export_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.robinhood.export_completed_stock_orders") as m:
+        out = await get_fn("rh_export_completed_stock_orders")(dir_path="/tmp")
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Error pass-through: SDK exceptions become structured errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rh_get_quotes_propagates_sdk_error_safely() -> None:
+    with patch("robin_stocks.robinhood.get_quotes", side_effect=RuntimeError("boom")):
+        out = await get_fn("rh_get_quotes")(inputSymbols="AAPL")
+        assert out["error"] is True
+        assert out["type"] == "RuntimeError"
+        assert "boom" in out["message"]
+
+
+# ---------------------------------------------------------------------------
+# Auth tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rh_login_passes_through_args() -> None:
+    with patch("robin_stocks.robinhood.login", return_value={"access_token": "t"}) as m:
+        out = await get_fn("rh_login")(username="u", password="p", mfa_code="123456")
+        m.assert_called_once()
+        _, kwargs = m.call_args
+        assert kwargs["username"] == "u"
+        assert kwargs["password"] == "p"
+        assert kwargs["mfa_code"] == "123456"
+        assert out == {"access_token": "t"}
+
+
+@pytest.mark.asyncio
+async def test_rh_logout_calls_logout() -> None:
+    with patch("robin_stocks.robinhood.logout") as m:
+        out = await get_fn("rh_logout")()
+        m.assert_called_once_with()
+        assert out == "ok: logged out of Robinhood"

--- a/tests/mcp/test_runtime.py
+++ b/tests/mcp/test_runtime.py
@@ -1,0 +1,83 @@
+"""Tests for the runtime helpers: thread offload, read-only guard, error capture."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from robin_stocks_mcp import runtime
+from robin_stocks_mcp.runtime import ReadOnlyError, format_error, safe_tool, to_thread
+
+
+def test_format_error_shape() -> None:
+    err = ValueError("nope")
+    out = format_error(err)
+    assert out == {"error": True, "type": "ValueError", "message": "nope"}
+
+
+def test_to_thread_runs_blocking_call() -> None:
+    import threading
+
+    main_tid = threading.get_ident()
+
+    def blocking() -> int:
+        return threading.get_ident()
+
+    result_tid = asyncio.run(to_thread(blocking))
+    assert result_tid != main_tid
+
+
+def test_safe_tool_catches_exceptions() -> None:
+    @safe_tool()
+    async def boom() -> None:
+        raise RuntimeError("kaboom")
+
+    out = asyncio.run(boom())
+    assert out["error"] is True
+    assert out["type"] == "RuntimeError"
+    assert "kaboom" in out["message"]
+
+
+def test_safe_tool_passes_through_success() -> None:
+    @safe_tool()
+    async def ok(x: int) -> int:
+        return x + 1
+
+    assert asyncio.run(ok(x=2)) == 3
+
+
+def test_safe_tool_write_blocked_in_read_only(writes_disabled: None) -> None:
+    @safe_tool(write=True)
+    async def write_op() -> str:
+        return "wrote"
+
+    out = asyncio.run(write_op())
+    assert out["error"] is True
+    assert out["type"] == "ReadOnlyError"
+
+
+def test_safe_tool_write_allowed_when_enabled(writes_enabled: None) -> None:
+    @safe_tool(write=True)
+    async def write_op() -> str:
+        return "wrote"
+
+    assert asyncio.run(write_op()) == "wrote"
+
+
+def test_safe_tool_handles_sync_function() -> None:
+    @safe_tool()
+    def sync_fn(x: int) -> int:
+        return x * 2
+
+    # safe_tool returns an async wrapper regardless; awaiting it should work.
+    assert asyncio.run(sync_fn(x=3)) == 6
+
+
+def test_require_writes_allowed_raises_when_read_only(writes_disabled: None) -> None:
+    with pytest.raises(ReadOnlyError):
+        runtime.require_writes_allowed("x")
+
+
+def test_require_writes_allowed_silent_when_enabled(writes_enabled: None) -> None:
+    runtime.require_writes_allowed("x")  # must not raise

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -1,0 +1,65 @@
+"""Higher-level integration test: exercise the FastMCP request handlers end-to-end.
+
+We don't open a stdio pipe — instead we call FastMCP's `list_tools` and `call_tool` methods
+directly. That mirrors what the MCP server does under the hood when a client connects.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from robin_stocks_mcp.app import mcp
+
+
+@pytest.mark.asyncio
+async def test_list_tools_via_fastmcp() -> None:
+    """`mcp.list_tools()` is the public method the MCP protocol uses."""
+    tools = await mcp.list_tools()
+    names = [t.name for t in tools]
+    assert "rh_get_quotes" in names
+    assert "tda_get_quote" in names
+    assert "gem_get_pubticker" in names
+    # No internal helpers leaked into the tool surface
+    assert "filter_data" not in names
+    assert "request_get" not in names
+
+
+@pytest.mark.asyncio
+async def test_call_tool_via_fastmcp_with_mocked_sdk() -> None:
+    """`mcp.call_tool()` is what the protocol dispatches to.
+
+    FastMCP returns either a list of `Content` blocks or a tuple of
+    (content_blocks, structured_payload) depending on version. Either way our SDK
+    return value must appear somewhere in the serialized output.
+    """
+    with patch(
+        "robin_stocks.robinhood.get_quotes", return_value=[{"symbol": "AAPL", "last": "1"}]
+    ):
+        result = await mcp.call_tool("rh_get_quotes", {"inputSymbols": "AAPL"})
+
+    serialized = json.dumps(result, default=str)
+    assert "AAPL" in serialized
+
+
+@pytest.mark.asyncio
+async def test_call_tool_unknown_name_errors() -> None:
+    """Calling a nonexistent tool through FastMCP raises (the SDK handles it)."""
+    with pytest.raises(Exception):
+        await mcp.call_tool("does_not_exist_xyz", {})
+
+
+@pytest.mark.asyncio
+async def test_call_write_tool_blocked_read_only(writes_disabled) -> None:
+    """Write tools return structured error payloads, not exceptions."""
+    with patch("robin_stocks.robinhood.order_buy_market") as m:
+        result = await mcp.call_tool(
+            "rh_order_buy_market", {"symbol": "AAPL", "quantity": 1}
+        )
+        m.assert_not_called()
+
+    # Confirm error markers appear in serialized result
+    serialized = json.dumps(result, default=str)
+    assert "ReadOnlyError" in serialized

--- a/tests/mcp/test_server_subprocess.py
+++ b/tests/mcp/test_server_subprocess.py
@@ -1,0 +1,158 @@
+"""End-to-end test: spawn the server as a subprocess over STDIO and round-trip MCP messages.
+
+This is the highest-fidelity test we can do offline — it confirms the entire pipeline
+(install entry point → argparse → FastMCP → JSON-RPC over stdio) actually works.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _send(proc: subprocess.Popen, msg: dict) -> None:
+    assert proc.stdin is not None
+    line = json.dumps(msg) + "\n"
+    proc.stdin.write(line)
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen, timeout_s: float = 10.0) -> dict:
+    assert proc.stdout is not None
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            time.sleep(0.05)
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            # FastMCP sometimes prints log lines on stdout; skip until JSON
+            continue
+    raise TimeoutError("server did not respond")
+
+
+@pytest.mark.timeout(30)
+def test_server_subprocess_lists_tools() -> None:
+    env = os.environ.copy()
+    env.setdefault("ROBIN_STOCKS_MCP_AUTO_LOGIN", "false")  # don't dial out
+    env.setdefault("ROBIN_STOCKS_MCP_READ_ONLY", "true")
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "robin_stocks_mcp.server", "--transport", "stdio"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    try:
+        # MCP handshake
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"},
+            },
+        })
+        init_resp = _recv(proc)
+        assert init_resp.get("id") == 1
+        assert "result" in init_resp, init_resp
+
+        # Required `notifications/initialized` after initialize
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+        # List tools
+        _send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        list_resp = _recv(proc)
+        assert list_resp.get("id") == 2
+        tools = list_resp["result"]["tools"]
+        names = {t["name"] for t in tools}
+        assert "rh_get_quotes" in names
+        assert "tda_get_quote" in names
+        assert "gem_get_pubticker" in names
+        assert len(tools) >= 180
+    finally:
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+
+@pytest.mark.timeout(30)
+def test_server_subprocess_blocks_write_in_read_only() -> None:
+    """Calling a write-guarded tool over real STDIO should come back as an error payload,
+    not crash the server."""
+    env = os.environ.copy()
+    env["ROBIN_STOCKS_MCP_AUTO_LOGIN"] = "false"
+    env["ROBIN_STOCKS_MCP_READ_ONLY"] = "true"
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "robin_stocks_mcp.server", "--transport", "stdio"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    try:
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"},
+            },
+        })
+        _recv(proc)
+        _send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "rh_order_buy_market",
+                "arguments": {"symbol": "AAPL", "quantity": 1},
+            },
+        })
+        resp = _recv(proc, timeout_s=15.0)
+        # FastMCP returns either an isError result or an error payload; either way the
+        # server must surface ReadOnlyError without crashing.
+        body = json.dumps(resp)
+        assert "ReadOnlyError" in body, body
+        assert resp.get("id") == 2
+    finally:
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()

--- a/tests/mcp/test_tda_tools.py
+++ b/tests/mcp/test_tda_tools.py
@@ -1,0 +1,88 @@
+"""Tests that TDA tools dispatch correctly to the SDK and enforce the write guard."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from robin_stocks_mcp.app import mcp
+
+
+def get_fn(name: str):
+    return mcp._tool_manager.get_tool(name).fn
+
+
+@pytest.mark.asyncio
+async def test_tda_login_dispatches() -> None:
+    with patch("robin_stocks.tda.login") as m:
+        out = await get_fn("tda_login")(encryption_passcode="pp")
+        m.assert_called_once_with("pp")
+        assert out == "ok: TDA login complete"
+
+
+@pytest.mark.asyncio
+async def test_tda_get_accounts_dispatches() -> None:
+    with patch("robin_stocks.tda.get_accounts", return_value=[{"id": "1"}]) as m:
+        out = await get_fn("tda_get_accounts")(options="positions")
+        m.assert_called_once_with(options="positions", jsonify=None)
+        assert out == [{"id": "1"}]
+
+
+@pytest.mark.asyncio
+async def test_tda_get_quote_dispatches() -> None:
+    with patch("robin_stocks.tda.get_quote", return_value={"AAPL": {}}) as m:
+        await get_fn("tda_get_quote")(ticker="AAPL")
+        m.assert_called_once_with("AAPL", jsonify=None)
+
+
+@pytest.mark.asyncio
+async def test_tda_get_price_history_dispatches() -> None:
+    with patch("robin_stocks.tda.get_price_history", return_value={"candles": []}) as m:
+        await get_fn("tda_get_price_history")(
+            ticker="AAPL",
+            period_type="day",
+            frequency_type="minute",
+            frequency="5",
+        )
+        args, _ = m.call_args
+        assert args[0:4] == ("AAPL", "day", "minute", "5")
+
+
+@pytest.mark.asyncio
+async def test_tda_place_order_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.tda.place_order") as m:
+        out = await get_fn("tda_place_order")(account_id="1", order_payload={"x": 1})
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tda_place_order_dispatches_when_enabled(writes_enabled) -> None:
+    with patch("robin_stocks.tda.place_order", return_value={"orderId": "abc"}) as m:
+        out = await get_fn("tda_place_order")(account_id="1", order_payload={"x": 1})
+        m.assert_called_once_with("1", {"x": 1}, jsonify=None)
+        assert out == {"orderId": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_tda_cancel_order_blocked_read_only(writes_disabled) -> None:
+    with patch("robin_stocks.tda.cancel_order") as m:
+        out = await get_fn("tda_cancel_order")(account_id="1", order_id="x")
+        assert out["error"] is True
+        m.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tda_get_option_chains_passes_kwargs() -> None:
+    with patch("robin_stocks.tda.get_option_chains", return_value={}) as m:
+        await get_fn("tda_get_option_chains")(ticker="AAPL", strike_count="5")
+        _, kwargs = m.call_args
+        assert kwargs["strike_count"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_tda_get_movers_dispatches() -> None:
+    with patch("robin_stocks.tda.get_movers", return_value=[]) as m:
+        await get_fn("tda_get_movers")(market="$DJI", direction="up", change="percent")
+        m.assert_called_once_with("$DJI", "up", "percent", jsonify=None)

--- a/tests/mcp/test_tool_registration.py
+++ b/tests/mcp/test_tool_registration.py
@@ -1,0 +1,43 @@
+"""Verify that every tool module registers tools with the FastMCP instance, and that
+each registered tool has the right name prefix, an input schema, and a docstring."""
+
+from __future__ import annotations
+
+from robin_stocks_mcp.app import mcp
+
+EXPECTED_PREFIXES = {"rh_", "tda_", "gem_"}
+
+
+def _all_tools():
+    return mcp._tool_manager.list_tools()
+
+
+def test_at_least_180_tools_registered() -> None:
+    """If we ever lose a module, the count will drop sharply."""
+    assert len(_all_tools()) >= 180, f"only {len(_all_tools())} tools registered"
+
+
+def test_every_tool_has_known_prefix() -> None:
+    bad = [t.name for t in _all_tools() if not any(t.name.startswith(p) for p in EXPECTED_PREFIXES)]
+    assert not bad, f"tools missing broker prefix: {bad}"
+
+
+def test_every_tool_has_description() -> None:
+    bad = [t.name for t in _all_tools() if not (t.description or "").strip()]
+    assert not bad, f"tools missing description: {bad}"
+
+
+def test_every_tool_has_input_schema() -> None:
+    bad = [t.name for t in _all_tools() if not isinstance(t.parameters, dict)]
+    assert not bad, f"tools missing input schema: {bad}"
+
+
+def test_no_duplicate_tool_names() -> None:
+    names = [t.name for t in _all_tools()]
+    assert len(names) == len(set(names)), "duplicate tool names registered"
+
+
+def test_login_tools_present() -> None:
+    names = {t.name for t in _all_tools()}
+    for required in ("rh_login", "rh_logout", "tda_login", "gem_login"):
+        assert required in names, f"missing required tool: {required}"


### PR DESCRIPTION
## Summary

Adds an opt-in `robin_stocks_mcp` package that exposes every public function of the `robinhood`, `tda`, and `gemini` submodules as [Model Context Protocol](https://modelcontextprotocol.io) tools — 188 in total. This makes the SDK directly usable from any MCP client (Claude Code, Claude Desktop, Cursor, Continue, custom agents) without users having to write any glue code.

- **Pure addition.** No existing public API changes. `mcp[cli]` lives behind a new `[mcp]` extra (`pip install -e ".[mcp]"`) so existing users see no new required dependency.
- **Reuses the SDK's own credential persistence as the default path.** New CLI subcommands `robin-stocks-mcp login` and `robin-stocks-mcp tda-setup` wrap the first-time interactive setup; subsequent runs reuse the pickle / encrypted store without prompting.
- **Read-only by default.** Order placement, cancellation, transfers, watchlist mutations, CSV exports, and document downloads return a structured `ReadOnlyError` until `ROBIN_STOCKS_MCP_READ_ONLY=false`.
- **Blocking SDK calls are offloaded** to a thread pool so the MCP event loop stays responsive.
- **Every tool catches exceptions** and returns structured `{error, type, message}` payloads instead of crashing the JSON-RPC transport.
- **Version bumped 3.4.0 → 3.5.0** per contributing.md (feature addition).
- **Docs in a separate commit** from code per contributing.md rule 1.

## Tool surface (sample)

| Tool                                      | What it does                       |
|-------------------------------------------|------------------------------------|
| `rh_get_quotes` / `rh_get_latest_price`   | Stock quotes                       |
| `rh_build_holdings`                       | Portfolio summary                  |
| `rh_get_stock_historicals`                | OHLC bars                          |
| `rh_find_tradable_options`                | Option chain search                |
| `rh_get_crypto_quote`                     | Crypto quote                       |
| `rh_order_buy_market` *(write-guarded)*   | Market buy                         |
| `tda_get_accounts` / `tda_get_quote`      | TDA account/quote                  |
| `tda_get_price_history`                   | TDA price history                  |
| `tda_place_order` *(write-guarded)*       | TDA order                          |
| `gem_get_pubticker`                       | Gemini public ticker               |
| `gem_check_available_balances`            | Gemini balances                    |
| `gem_order` *(write-guarded)*             | Gemini order                       |

## Test plan

- [x] 84 offline tests under `tests/mcp/` cover the runtime helpers, env-var parsing, auth bootstrap (pickle reuse + env fallback), tool registration, dispatch via mocks, write-guard enforcement, error capture, the CLI subcommands, and an end-to-end subprocess test that boots the server over STDIO and completes the MCP handshake.
- [x] All tests run without broker credentials — every SDK call is mocked via `unittest.mock`, so no real orders are placed.
- [x] Run locally with `pip install -e ".[mcp,dev]" && pytest tests/mcp -q` → 84 passed.
- [ ] Existing `tests/test_{robinhood,gemini,tda}.py` not run locally (require GitHub Secrets); maintainer's CI will verify.

## Compliance with contributing.md

| # | Requirement                                                | Status                                      |
|---|------------------------------------------------------------|---------------------------------------------|
| 1 | Grammar/docs changes in a separate commit from code        | ✅ Two commits; second is README-only       |
| 2 | Update `__init__.py` to import new functions               | N/A — does not extend the SDK surface       |
| 3 | Bump version in `setup.py` (YY for features)               | ✅ 3.4.0 → 3.5.0                            |
| 4 | Write tests covering new code                              | ✅ 84 tests                                  |
| 5 | Don't write tests that place real orders                   | ✅ All SDK calls mocked                     |

🤖 Generated with [Claude Code](https://claude.com/claude-code)